### PR TITLE
Make the webpack an array for downstream.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,33 +1,35 @@
 const path = require('path');
 
-module.exports = {
-    target: 'node',
-    mode: 'none',
-    context: __dirname,
-    resolve: {
-        extensions: [ '.ts', '.js' ]
-    },
-    entry: {
-        debugAdapter: './src/debugAdapter.ts'
-    },
-    output: {
-        path: path.resolve(__dirname, 'out'),
-        filename: '[name].js',
-        libraryTarget: 'commonjs',
-        devtoolModuleFilenameTemplate: '[absolute-resource-path]'
-    },
-    devtool: 'source-map',
-    module: {
-        rules: [
-            {
-                test: /\.ts$/,
-                loader: 'ts-loader',
-                options: {
-                    compilerOptions: {
-                        sourceMap: true
+module.exports = [
+    {
+        target: 'node',
+        mode: 'none',
+        context: __dirname,
+        resolve: {
+            extensions: [ '.ts', '.js' ]
+        },
+        entry: {
+            debugAdapter: './src/debugAdapter.ts'
+        },
+        output: {
+            path: path.resolve(__dirname, 'out'),
+            filename: '[name].js',
+            libraryTarget: 'commonjs',
+            devtoolModuleFilenameTemplate: '[absolute-resource-path]'
+        },
+        devtool: 'source-map',
+        module: {
+            rules: [
+                {
+                    test: /\.ts$/,
+                    loader: 'ts-loader',
+                    options: {
+                        compilerOptions: {
+                            sourceMap: true
+                        }
                     }
                 }
-            }
-        ]
+            ]
+        }
     }
-};
+];


### PR DESCRIPTION
This allows us to add multiple configs if needed
in the future without impacting downstream consumers
like cdg-gdb-vscode.