### PR TITLE
Make module importable, add getExecPath function

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "cdt-gdb-adapter",
   "version": "0.1.0",
   "description": "gdb adapter implementing the debug adapter protocol",
-  "main": "index.js",
+  "main": "out/index.js",
+  "types": "out/index.d.ts",
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,18 @@
+/*********************************************************************
+ * Copyright (c) 2018 Ericsson and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+import * as path from 'path';
+
+/**
+ * Return the path to the debug adapter entry point.
+ */
+export function getExecPath(): string {
+    return path.join(__dirname, 'debugAdapter.js');
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
         ],
         "outDir": "out",
         "sourceMap": true,
+	"declaration": true,
         "strict": true,
         "noImplicitAny": true,
         "noImplicitReturns": true,
@@ -15,7 +16,7 @@
         "allowSyntheticDefaultImports": true,
         "experimentalDecorators": true
     },
-    "exclude": [
-        "node_modules"
+    "include": [
+        "src/**/*.ts"
     ]
 }


### PR DESCRIPTION
The getExecPath returns the absolute path to the debug adapter entry
point.  The idea is that a javascript/typescript application can depend
on the cdt-gdb-adapter module, and call getExecPath to know which file
to spawn in order to start the adapter.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>