### PR TITLE
Add tslint-language-service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -679,6 +679,15 @@
         "unset-value": "^1.0.0"
       }
     },
+    "caller-id": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-id/-/caller-id-0.1.0.tgz",
+      "integrity": "sha1-Wb2sCJPRLDhxQIJ5Ix+XRYNk8Hs=",
+      "dev": true,
+      "requires": {
+        "stack-trace": "~0.0.7"
+      }
+    },
     "camelcase": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -2657,6 +2666,15 @@
         "minimist": "0.0.8"
       }
     },
+    "mock-require": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mock-require/-/mock-require-2.0.2.tgz",
+      "integrity": "sha1-HqpxqtIwE3c9En3H6Ro/u0g31g0=",
+      "dev": true,
+      "requires": {
+        "caller-id": "^0.1.0"
+      }
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -3498,6 +3516,12 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+      "dev": true
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -3711,6 +3735,15 @@
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
         "tsutils": "^2.27.2"
+      }
+    },
+    "tslint-language-service": {
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/tslint-language-service/-/tslint-language-service-0.9.9.tgz",
+      "integrity": "sha1-9UbcOEg5eeb7PPpZWErYUls61No=",
+      "dev": true,
+      "requires": {
+        "mock-require": "^2.0.2"
       }
     },
     "tsutils": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/node": "^10.12.2",
     "ts-loader": "^5.3.0",
     "tslint": "^5.11.0",
+    "tslint-language-service": "^0.9.9",
     "typescript": "^3.1.5",
     "webpack": "^4.23.1",
     "webpack-cli": "^3.1.2"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,12 @@
         "noImplicitReturns": true,
         "noUnusedLocals": true,
         "allowSyntheticDefaultImports": true,
-        "experimentalDecorators": true
+        "experimentalDecorators": true,
+        "plugins": [
+            {
+                "name": "tslint-language-service"
+            }
+        ]
     },
     "include": [
         "src/**/*.ts"


### PR DESCRIPTION
This patch allows seeing tslint warnings and errors in Theia, where
tslint must be used through the tslint-language-sevice plugin of tsc.
It doesn't seem to affect the editing experiecne in VSCode.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>