### PR TITLE
Fix calls to sendErrorResponse

### DIFF
--- a/src/GDBBackend.ts
+++ b/src/GDBBackend.ts
@@ -75,15 +75,15 @@ export class GDBBackend extends events.EventEmitter {
                             resolve(result);
                             break;
                         case 'error':
-                            reject(result);
+                            reject(new Error(result.msg));
                             break;
                         default:
-                            reject('Unknown response ' + JSON.stringify(result));
+                            reject(new Error('Unknown response ' + JSON.stringify(result)));
                     }
                 });
                 this.out.write(`${token}${command}\n`);
             } else {
-                reject('gdb is not running.');
+                reject(new Error('gdb is not running.'));
             }
         });
     }

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -91,7 +91,7 @@ export class GDBDebugSession extends LoggingDebugSession {
             this.sendEvent(new InitializedEvent());
             this.sendResponse(response);
         } catch (err) {
-            this.sendErrorResponse(response, 1, err);
+            this.sendErrorResponse(response, 1, err.message);
         }
     }
 
@@ -115,7 +115,7 @@ export class GDBDebugSession extends LoggingDebugSession {
             this.sendEvent(new InitializedEvent());
             this.sendResponse(response);
         } catch (err) {
-            this.sendErrorResponse(response, 1, err);
+            this.sendErrorResponse(response, 1, err.message);
         }
     }
 
@@ -176,7 +176,7 @@ export class GDBDebugSession extends LoggingDebugSession {
 
             this.sendResponse(response);
         } catch (err) {
-            this.sendErrorResponse(response, 1, err);
+            this.sendErrorResponse(response, 1, err.message);
         }
     }
 
@@ -191,7 +191,7 @@ export class GDBDebugSession extends LoggingDebugSession {
             this.isRunning = true;
             this.sendResponse(response);
         } catch (err) {
-            this.sendErrorResponse(response, 100, err);
+            this.sendErrorResponse(response, 100, err.message);
         }
     }
 
@@ -215,7 +215,7 @@ export class GDBDebugSession extends LoggingDebugSession {
 
             this.sendResponse(response);
         } catch (err) {
-            this.sendErrorResponse(response, 1, err);
+            this.sendErrorResponse(response, 1, err.message);
         }
     }
 
@@ -252,7 +252,7 @@ export class GDBDebugSession extends LoggingDebugSession {
 
             this.sendResponse(response);
         } catch (err) {
-            this.sendErrorResponse(response, 1, err);
+            this.sendErrorResponse(response, 1, err.message);
         }
     }
 
@@ -262,7 +262,7 @@ export class GDBDebugSession extends LoggingDebugSession {
             await exec.sendExecNext(this.gdb);
             this.sendResponse(response);
         } catch (err) {
-            this.sendErrorResponse(response, 1, err);
+            this.sendErrorResponse(response, 1, err.message);
         }
     }
 
@@ -272,7 +272,7 @@ export class GDBDebugSession extends LoggingDebugSession {
             await exec.sendExecStep(this.gdb);
             this.sendResponse(response);
         } catch (err) {
-            this.sendErrorResponse(response, 1, err);
+            this.sendErrorResponse(response, 1, err.message);
         }
     }
 
@@ -282,7 +282,7 @@ export class GDBDebugSession extends LoggingDebugSession {
             await exec.sendExecFinish(this.gdb);
             this.sendResponse(response);
         } catch (err) {
-            this.sendErrorResponse(response, 1, err);
+            this.sendErrorResponse(response, 1, err.message);
         }
     }
 
@@ -292,7 +292,7 @@ export class GDBDebugSession extends LoggingDebugSession {
             await exec.sendExecContinue(this.gdb);
             this.sendResponse(response);
         } catch (err) {
-            this.sendErrorResponse(response, 1, err);
+            this.sendErrorResponse(response, 1, err.message);
         }
     }
 
@@ -452,8 +452,8 @@ export class GDBDebugSession extends LoggingDebugSession {
                 }
             }
             this.sendResponse(response);
-    } catch (err) {
-            this.sendErrorResponse(response, 1, err);
+        } catch (err) {
+            this.sendErrorResponse(response, 1, err.message);
         }
     }
 
@@ -522,7 +522,7 @@ export class GDBDebugSession extends LoggingDebugSession {
                 }
             }
         } catch (err) {
-            this.sendErrorResponse(response, 1, err);
+            this.sendErrorResponse(response, 1, err.message);
         }
     }
 
@@ -532,7 +532,7 @@ export class GDBDebugSession extends LoggingDebugSession {
             await this.gdb.sendGDBExit();
             this.sendResponse(response);
         } catch (err) {
-            this.sendErrorResponse(response, 1, err);
+            this.sendErrorResponse(response, 1, err.message);
         }
     }
 


### PR DESCRIPTION
At GDBBackend.ts:78, we reject a Promise with an object.  That rejected
promise may become an exception, caught for example in
setBreakPointsRequest at GDBDebugSession.ts:178.  That object is then
passed to sendErrorResponse.  The problem is that sendErrorResponse
expects to receive a string.  So it fails with:

```
(node:2643) UnhandledPromiseRejectionWarning: TypeError: format.replace is not a function
    at Function.formatPII (/home/emaisin/src/cdt-gdb-adapter/node_modules/vscode-debugadapter/lib/debugSession.js:669:23)
    at GDBDebugSession.sendErrorResponse (/home/emaisin/src/cdt-gdb-adapter/node_modules/vscode-debugadapter/lib/debugSession.js:310:41)
    at GDBDebugSession.<anonymous> (/home/emaisin/src/cdt-gdb-adapter/out/GDBDebugSession.js:137:22)
    at Generator.throw (<anonymous>)
    at rejected (/home/emaisin/src/cdt-gdb-adapter/out/GDBDebugSession.js:5:65)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:189:7)
```

Unfortunately, exceptions in Typescript are not typed, so it's difficult to
make sure what kind of object we caught.  To circumvent this, I suggest
we make sure to always throw and reject with Error (or subclasses of
it) containing a message.  This way, we know that we can use err.message
as an error message.

With this fix, a failed request is properly handled, we send a response
with "success":"false" to the client.