### PR TITLE
Add 'Set Value' Functionality for Variables

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -501,7 +501,7 @@ export class GDBDebugSession extends LoggingDebugSession {
                 response.body = {value: args.value};
             }
         } catch (err) {
-            this.sendErrorResponse(response, 1, err);
+            this.sendErrorResponse(response, 1, err.message);
         }
         this.sendResponse(response);
     }

--- a/src/mi/var.ts
+++ b/src/mi/var.ts
@@ -46,6 +46,10 @@ export interface MIVarUpdateResponse {
     }>;
 }
 
+export interface MIVarEvalResponse {
+    value: string;
+}
+
 export function sendVarCreate(gdb: GDBBackend, params: {
   name?: string;
   frameAddr?: string;
@@ -109,5 +113,20 @@ export function sendVarDelete(gdb: GDBBackend, params: {
     varname: string,
 }): Promise<void> {
     const command = `-var-delete ${params.varname}`;
+    return gdb.sendCommand(command);
+}
+
+export function sendVarAssign(gdb: GDBBackend, params: {
+    varname: string,
+    expression: string,
+}): Promise<void> {
+    const command = `-var-assign ${params.varname} ${params.expression}`;
+    return gdb.sendCommand(command);
+}
+
+export function sendVarEvaluateExpression(gdb: GDBBackend, params: {
+    varname: string,
+}): Promise<MIVarEvalResponse> {
+    const command = `-var-evaluate-expression ${params.varname}`;
     return gdb.sendCommand(command);
 }


### PR DESCRIPTION
Adds the ability to right-click > Set Value on most variables.

Limitations:
-Defined length arrays display the value of the array length when first
created, and the value of the first array entry that gets updated after
subsequent checks. It would be more useful to display the address the
array is located at in memory.
-Parent and child entries in the Variables tree are not updated when a
value is set, only the variable that was modified. This is purposefully
defined behavior by VS Code but not clear if this is modifiable.
-There exists a hook in the Debug Protocol to set expressions. I have not
yet found a way to trigger a SetExpressionRequest.

Refs eclipse-cdt#15

Change-Id: I6d3c072bf9e6438cd2f5371f87e8cfeb53da6ca5
Signed-off-by: Jonathan Williams <jonwilliams@blackberry.com>