### PR TITLE
Add code code to build test program before running test.

### DIFF
--- a/src/integration-tests/launch.spec.ts
+++ b/src/integration-tests/launch.spec.ts
@@ -21,7 +21,7 @@ const emptyProgram = path.join(__dirname, '..', '..', 'src', 'integration-tests'
 
 before(function() {
     // Build the test program
-    cp.execSync('make', { cwd: path.dirname(emptyProgram)});
+    cp.execSync('make', { cwd: path.dirname(emptyProgram) });
 
     let args: string = getExecPath();
     if (process.env.INSPECT_DEBUG_ADAPTER) {

--- a/src/integration-tests/launch.spec.ts
+++ b/src/integration-tests/launch.spec.ts
@@ -17,11 +17,12 @@ import { getExecPath } from '..';
 // tslint:disable:only-arrow-functions
 
 let dc: DebugClient;
-const emptyProgram = path.join(__dirname, '..', '..', 'src', 'integration-tests', 'test-programs', 'empty');
+const testProgramsDir = path.join(__dirname, '..', '..', 'src', 'integration-tests', 'test-programs');
+const emptyProgram = path.join(testProgramsDir, 'empty');
 
 before(function() {
     // Build the test program
-    cp.execSync('make', { cwd: path.dirname(emptyProgram) });
+    cp.execSync('make', { cwd: testProgramsDir });
 
     let args: string = getExecPath();
     if (process.env.INSPECT_DEBUG_ADAPTER) {

--- a/src/integration-tests/launch.spec.ts
+++ b/src/integration-tests/launch.spec.ts
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *********************************************************************/
 
+import * as cp from 'child_process';
 import * as path from 'path';
 import { DebugClient } from 'vscode-debugadapter-testsupport';
 import { getExecPath } from '..';
@@ -19,6 +20,9 @@ let dc: DebugClient;
 const emptyProgram = path.join(__dirname, '..', '..', 'src', 'integration-tests', 'test-programs', 'empty');
 
 before(function() {
+    // Build the test program
+    cp.execSync('make', { cwd: path.dirname(emptyProgram)});
+
     let args: string = getExecPath();
     if (process.env.INSPECT_DEBUG_ADAPTER) {
         args = '--inspect-brk ' + args;


### PR DESCRIPTION
Test fails without it and we want to keep the build of the test
programs close to the tests that need them.