### PR TITLE
Use -file-exec-and-symbol to specify binary

### DIFF
--- a/src/GDBBackend.ts
+++ b/src/GDBBackend.ts
@@ -48,7 +48,7 @@ export class GDBBackend extends events.EventEmitter {
 
     public launch(args: LaunchRequestArguments) {
         const gdb = args.gdb ? args.gdb : 'gdb';
-        const proc = spawn(gdb, ['--interpreter=mi2', args.program]);
+        const proc = spawn(gdb, ['--interpreter=mi2']);
         this.out = proc.stdin;
         return this.parser.parse(proc.stdout);
     }
@@ -98,6 +98,10 @@ export class GDBBackend extends events.EventEmitter {
 
     public sendEnablePrettyPrint() {
         return this.sendCommand('-enable-pretty-printing');
+    }
+
+    public sendFileExecAndSymbols(program: string) {
+        return this.sendCommand(`-file-exec-and-symbols ${program}`);
     }
 
     public sendGDBExit() {

--- a/src/integration-tests/launch.spec.ts
+++ b/src/integration-tests/launch.spec.ts
@@ -8,6 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  *********************************************************************/
 
+import { expect } from 'chai';
 import * as cp from 'child_process';
 import * as path from 'path';
 import { DebugClient } from 'vscode-debugadapter-testsupport';
@@ -60,5 +61,18 @@ describe('launch', function() {
         });
         await dc.configurationDoneRequest({});
         await dc.assertStoppedLocation('breakpoint', {});
+    });
+
+    it('reports an error when specifying a non-existent binary', async function() {
+        const errorMessage = await new Promise<Error>((resolve, reject) => {
+            dc.launchRequest({
+                verbose: true,
+                program: '/does/not/exist',
+            } as any)
+                .then(reject)
+                .catch(resolve);
+        });
+
+        expect(errorMessage.message).eq('/does/not/exist: No such file or directory.');
     });
 });


### PR DESCRIPTION
We currently pass the program name on the GDB command line.  If, for
example, the program does not exist, the failure is silent (GDB outputs
an error as CLI output, but that's it).  The failure only manifests
itself when we try to run, but at this point the error is not precise:

    Error: No executable file specified.
    Use the "file" or "exec-file" command.

By using -file-exec-and-symbols, we are able to get a more precise
error:

    /does/not/exist: No such file or directory.

Fixes #29.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>