### PR TITLE
Disable tslint align rule for parameters and arguments

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,12 @@
     "tslint:recommended"
   ],
   "rules": {
+    "align": [
+      true,
+      "statements",
+      "members",
+      "elements"
+    ],
     "interface-name": false,
     "no-empty-interface": false,
     "object-literal-sort-keys": false,


### PR DESCRIPTION
Since the Typescript auto formatting clashes with this rule, it's
simpler to just disable it.  In practice, the Typescript formatter does
this:

    functionCall(a, b, c,
        d, e, f);

and this tslint rules wants it like this:

  functionCall(a, b, c,
               d, e, f);

Even though I prefer what tslint wants, it's annoying to fight against
the auto formatter.  Let's hope that some day, the Typescript formatter
becomes configurable in that regard.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>