### PR TITLE
Start/stop debug adapter for each test

### DIFF
--- a/src/integration-tests/launch.spec.ts
+++ b/src/integration-tests/launch.spec.ts
@@ -24,7 +24,9 @@ const emptyProgram = path.join(testProgramsDir, 'empty');
 before(function() {
     // Build the test program
     cp.execSync('make', { cwd: testProgramsDir });
+});
 
+beforeEach(async function() {
     let args: string = getExecPath();
     if (process.env.INSPECT_DEBUG_ADAPTER) {
         args = '--inspect-brk ' + args;
@@ -33,12 +35,12 @@ before(function() {
     dc = new DebugClient('node', args, 'cppdbg', {
         shell: true,
     });
-    dc.start();
-    dc.initializeRequest();
+    await dc.start();
+    await dc.initializeRequest();
 });
 
-after(function() {
-    dc.stop();
+afterEach(async function() {
+    await dc.stop();
 });
 
 describe('launch', function() {


### PR DESCRIPTION
In launch.spec.ts, we start the debug adapter once and run the two tests
with it.  The tests should be isolated from each other as much as
possible, so we should start a new debug adapter for each test.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>