### PR TITLE
Export all symbols from mi directory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -974,16 +974,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "cross-env": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
-      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^6.0.5",
-        "is-windows": "^1.0.0"
-      }
-    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",

--- a/src/mi/index.ts
+++ b/src/mi/index.ts
@@ -1,0 +1,16 @@
+/*********************************************************************
+ * Copyright (c) 2018 Ericsson and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+export * from './base';
+export * from './breakpoint';
+export * from './exec';
+export * from './stack';
+export * from './target';
+export * from './thread';
+export * from './var';


### PR DESCRIPTION
Instead of importing all MI commands-related functions under mi/
separately, add an index.ts which exports everything from the mi
directory.  This lets us have a single import for all mi commands.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>