### PR TITLE
Add Mocha Launch Configurationss to workspace

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,33 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha All",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "--timeout",
+        "999999",
+        "--colors",
+        "${workspaceFolder}/dist/integration-tests/*.spec.js"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Mocha Current File",
+      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "--timeout",
+        "999999",
+        "--colors",
+        "${file}"
+      ],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    }
+  ]
+}

--- a/src/integration-tests/README.md
+++ b/src/integration-tests/README.md
@@ -12,13 +12,14 @@ session.  It uses the `gdb` in your `PATH`.
 
 ## Debugging tips
 
-Defining the `INSPECT_DEBUG_ADAPTER` environment variable will cause the
-testsuite to pass the `--inspect-brk` flag to the node interpreter running the
-debug adapter.  This lets you attach with a debugger and resume execution.
+To debug, use the included launch configurations in the launch.json file for this vscode project.
 
-One easily available debugger is built in the Chromium/Chrome browser.  Navigate
-to [chrome://inspect](chrome://inspect), the debug adapter waiting to be
-attached to should appear under "Remote Target".
+'Mocha All' will run all compiled spec.js files in the {workspace}/dist/integration-tests/ directory.
+'Mocha Current File' will run the currently open spec.js file in the editor window. You can find the corresponding spec.js file for a given spec.ts file in the directory listed above.
+
+Breakpoints can be set in the corresponding spec.ts file and will work as expected, though stepping 
+may take you into compiled or framework .js files. 
+It may be possible with some additional configuration to run the spec.ts files directly.
 
 When debugging a test case, you will likely want to run just this one.  You can
 do so by changing the test declaration:


### PR DESCRIPTION
Adds Mocha launch configurations to this workspace.

'Mocha All' will run all compiled *.spec.js files in the
{workspace}/dist/integration-tests/ directory.

'Mocha Current File' will run the currently open spec.js file in the
editor window.

Breakpoints can be set in the corresponding .ts file and will work as
expected.

Change-Id: I38a88fc0ef9c6de091dc283ddd750a9d938879f6
Signed-off-by: Jonathan Williams <jonwilliams@blackberry.com>