### PR TITLE
Clean up termination.

### DIFF
--- a/src/debugAdapter.ts
+++ b/src/debugAdapter.ts
@@ -7,7 +7,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *********************************************************************/
-import * as process from 'process';
 import { logger } from 'vscode-debugadapter/lib/logger';
 import { GDBDebugSession } from './GDBDebugSession';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "noUnusedLocals": true,
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,
+    "preserveWatchOutput": true,
     "plugins": [
       {
         "name": "tslint-language-service"


### PR DESCRIPTION
On exit we need to interrupt gdb for the exit command to work
without hanging. For remote targets, we also need to kill the inferior.
That should be fine for local targets as well.

This change adds interrupt to the backend and then changes
the disconnnect request to follow the steps above.

Also fix up logger. When subclassing we had trouble getting the right
logger setup.