### PR TITLE
Factor out some common test code

### DIFF
--- a/src/integration-tests/launch.spec.ts
+++ b/src/integration-tests/launch.spec.ts
@@ -9,34 +9,21 @@
  *********************************************************************/
 
 import { expect } from 'chai';
-import * as cp from 'child_process';
 import * as path from 'path';
 import { DebugClient } from 'vscode-debugadapter-testsupport';
+import { standardBefore, standardBeforeEach, testProgramsDir } from './utils';
 
 // Allow non-arrow functions: https://mochajs.org/#arrow-functions
 // tslint:disable:only-arrow-functions
 
 let dc: DebugClient;
-const testProgramsDir = path.join(__dirname, '..', '..', 'src', 'integration-tests', 'test-programs');
 const emptyProgram = path.join(testProgramsDir, 'empty');
 const emptySrc = path.join(testProgramsDir, 'empty.c');
 
-before(function() {
-    // Build the test program
-    cp.execSync('make', { cwd: testProgramsDir });
-});
+before(standardBefore);
 
 beforeEach(async function() {
-    let args: string = path.join(__dirname, '..', 'debugAdapter.js');
-    if (process.env.INSPECT_DEBUG_ADAPTER) {
-        args = '--inspect-brk ' + args;
-    }
-
-    dc = new DebugClient('node', args, 'gdb', {
-        shell: true,
-    });
-    await dc.start();
-    await dc.initializeRequest();
+    dc = await standardBeforeEach();
 });
 
 afterEach(async function() {

--- a/src/integration-tests/mem.spec.ts
+++ b/src/integration-tests/mem.spec.ts
@@ -9,39 +9,23 @@
  *********************************************************************/
 
 import { expect } from 'chai';
-import * as cp from 'child_process';
 import * as path from 'path';
 import { DebugClient } from 'vscode-debugadapter-testsupport';
 import { DebugProtocol } from 'vscode-debugprotocol/lib/debugProtocol';
 import { MemoryResponse } from '../GDBDebugSession';
-import { expectRejection } from './utils';
+import { expectRejection, standardBeforeEach, testProgramsDir } from './utils';
 
 // Allow non-arrow functions: https://mochajs.org/#arrow-functions
 // tslint:disable:only-arrow-functions
 
 let dc: DebugClient;
 let scope: DebugProtocol.Scope;
-const testProgramsDir = path.join(__dirname, '..', '..', 'src', 'integration-tests', 'test-programs');
 const memProgram = path.join(testProgramsDir, 'mem');
 const memSrc = path.join(testProgramsDir, 'mem.c');
 
-function getAdapterAndArgs(): string {
-    let args: string = path.join(__dirname, '..', 'debugAdapter.js');
-    if (process.env.INSPECT_DEBUG_ADAPTER) {
-        args = '--inspect-brk ' + args;
-    }
-    return args;
-}
-
 beforeEach(async function() {
-    // Build the test program
-    cp.execSync('make', { cwd: testProgramsDir });
+    dc = await standardBeforeEach();
 
-    dc = new DebugClient('node', getAdapterAndArgs(), 'cppdbg', {
-        shell: true,
-    });
-    await dc.start();
-    await dc.initializeRequest();
     await dc.hitBreakpoint({
         program: memProgram,
     }, { path: memSrc, line: 12 });

--- a/src/integration-tests/var.spec.ts
+++ b/src/integration-tests/var.spec.ts
@@ -9,37 +9,26 @@
  *********************************************************************/
 
 import { expect } from 'chai';
-import * as cp from 'child_process';
 import * as path from 'path';
 import { DebugClient } from 'vscode-debugadapter-testsupport';
-import * as utils from './utils';
+import { getScopes, Scope, standardBefore, standardBeforeEach, testProgramsDir, verifyVariable } from './utils';
 
 // Allow non-arrow functions: https://mochajs.org/#arrow-functions
 // tslint:disable:only-arrow-functions
 
 let dc: DebugClient;
-let scope: utils.Scope;
-const testProgramsDir = path.join(__dirname, '..', '..', 'src', 'integration-tests', 'test-programs');
+let scope: Scope;
 const varsProgram = path.join(testProgramsDir, 'vars');
 const varsSrc = path.join(testProgramsDir, 'vars.c');
 const numVars = 8; // number of variables in the main() scope of vars.c
 
+before(standardBefore);
+
 beforeEach(async function() {
-    // Build the test program
-    cp.execSync('make', { cwd: testProgramsDir });
+    dc = await standardBeforeEach();
 
-    let args: string = path.join(__dirname, '..', 'debugAdapter.js');
-    if (process.env.INSPECT_DEBUG_ADAPTER) {
-        args = '--inspect-brk ' + args;
-    }
-
-    dc = new DebugClient('node', args, 'gdb', {
-        shell: true,
-    });
-    await dc.start();
-    await dc.initializeRequest();
     await dc.hitBreakpoint({ verbose: true, program: varsProgram }, { path: varsSrc, line: 19 });
-    scope = await utils.getScopes(dc);
+    scope = await getScopes(dc);
     expect(scope.scopes.body.scopes.length, 'Unexpected number of scopes returned').to.equal(1);
 });
 
@@ -57,43 +46,43 @@ describe('Variables Test Suite', function() {
         const vr = scope.scopes.body.scopes[0].variablesReference;
         let vars = await dc.variablesRequest({ variablesReference: vr });
         expect(vars.body.variables.length, 'There is a different number of variables than expected').to.equal(numVars);
-        utils.verifyVariable(vars.body.variables[0], 'a', 'int', '1');
-        utils.verifyVariable(vars.body.variables[1], 'b', 'int', '2');
+        verifyVariable(vars.body.variables[0], 'a', 'int', '1');
+        verifyVariable(vars.body.variables[1], 'b', 'int', '2');
         // set the variables to something different
         await dc.setVariableRequest({ name: 'a', value: '25', variablesReference: vr });
         await dc.setVariableRequest({ name: 'b', value: '10', variablesReference: vr });
         // assert that the variables have been updated to the new values
         vars = await dc.variablesRequest({ variablesReference: vr });
         expect(vars.body.variables.length, 'There is a different number of variables than expected').to.equal(numVars);
-        utils.verifyVariable(vars.body.variables[0], 'a', 'int', '25');
-        utils.verifyVariable(vars.body.variables[1], 'b', 'int', '10');
+        verifyVariable(vars.body.variables[0], 'a', 'int', '25');
+        verifyVariable(vars.body.variables[1], 'b', 'int', '10');
         // step the program and see that the values were passed to the program and evaluated.
         await dc.nextRequest({ threadId: scope.threadId });
         vars = await dc.variablesRequest({ variablesReference: vr });
         expect(vars.body.variables.length, 'There is a different number of variables than expected').to.equal(numVars);
-        utils.verifyVariable(vars.body.variables[2], 'c', 'int', '35');
+        verifyVariable(vars.body.variables[2], 'c', 'int', '35');
     });
 
     it('can read and set struct variables in a program', async function() {
         // step past the initialization for the structure
         await dc.nextRequest({ threadId: scope.threadId });
         await dc.nextRequest({ threadId: scope.threadId });
-        scope = await utils.getScopes(dc);
+        scope = await getScopes(dc);
         expect(scope.scopes.body.scopes.length, 'Unexpected number of scopes returned').to.equal(1);
         // assert we can see the struct and its elements
         let vr = scope.scopes.body.scopes[0].variablesReference;
         let vars = await dc.variablesRequest({ variablesReference: vr });
         expect(vars.body.variables.length, 'There is a different number of variables than expected').to.equal(numVars);
-        utils.verifyVariable(vars.body.variables[3], 'r', 'struct foo', '{...}', true);
+        verifyVariable(vars.body.variables[3], 'r', 'struct foo', '{...}', true);
         const childVR = vars.body.variables[3].variablesReference;
         let children = await dc.variablesRequest({ variablesReference: childVR });
         expect(
             children.body.variables.length,
             'There is a different number of child variables than expected',
         ).to.equal(3);
-        utils.verifyVariable(children.body.variables[0], 'x', 'int', '1');
-        utils.verifyVariable(children.body.variables[1], 'y', 'int', '2');
-        utils.verifyVariable(children.body.variables[2], 'z', 'struct bar', '{...}', true);
+        verifyVariable(children.body.variables[0], 'x', 'int', '1');
+        verifyVariable(children.body.variables[1], 'y', 'int', '2');
+        verifyVariable(children.body.variables[2], 'z', 'struct bar', '{...}', true);
         // set the variables to something different
         await dc.setVariableRequest({ name: 'x', value: '25', variablesReference: childVR });
         await dc.setVariableRequest({ name: 'y', value: '10', variablesReference: childVR });
@@ -103,36 +92,36 @@ describe('Variables Test Suite', function() {
             children.body.variables.length,
             'There is a different number of child variables than expected',
         ).to.equal(3);
-        utils.verifyVariable(children.body.variables[0], 'x', 'int', '25');
-        utils.verifyVariable(children.body.variables[1], 'y', 'int', '10');
+        verifyVariable(children.body.variables[0], 'x', 'int', '25');
+        verifyVariable(children.body.variables[1], 'y', 'int', '10');
         // step the program and see that the values were passed to the program and evaluated.
         await dc.nextRequest({ threadId: scope.threadId });
-        scope = await utils.getScopes(dc);
+        scope = await getScopes(dc);
         expect(scope.scopes.body.scopes.length, 'Unexpected number of scopes returned').to.equal(1);
         vr = scope.scopes.body.scopes[0].variablesReference;
         vars = await dc.variablesRequest({ variablesReference: vr });
         expect(vars.body.variables.length, 'There is a different number of variables than expected').to.equal(numVars);
-        utils.verifyVariable(vars.body.variables[4], 'd', 'int', '35');
+        verifyVariable(vars.body.variables[4], 'd', 'int', '35');
     });
 
     it('can read and set nested struct variables in a program', async function() {
         // step past the initialization for the structure
         await dc.nextRequest({ threadId: scope.threadId });
         await dc.nextRequest({ threadId: scope.threadId });
-        scope = await utils.getScopes(dc);
+        scope = await getScopes(dc);
         expect(scope.scopes.body.scopes.length, 'Unexpected number of scopes returned').to.equal(1);
         // assert we can see the 'foo' struct and its child 'bar' struct
         let vr = scope.scopes.body.scopes[0].variablesReference;
         let vars = await dc.variablesRequest({ variablesReference: vr });
         expect(vars.body.variables.length, 'There is a different number of variables than expected').to.equal(numVars);
-        utils.verifyVariable(vars.body.variables[3], 'r', 'struct foo', '{...}', true);
+        verifyVariable(vars.body.variables[3], 'r', 'struct foo', '{...}', true);
         const childVR = vars.body.variables[3].variablesReference;
         const children = await dc.variablesRequest({ variablesReference: childVR });
         expect(
             children.body.variables.length,
             'There is a different number of child variables than expected',
         ).to.equal(3);
-        utils.verifyVariable(children.body.variables[2], 'z', 'struct bar', '{...}', true);
+        verifyVariable(children.body.variables[2], 'z', 'struct bar', '{...}', true);
         // assert we can see the elements of z
         const subChildVR = children.body.variables[2].variablesReference;
         let subChildren = await dc.variablesRequest({ variablesReference: subChildVR });
@@ -140,8 +129,8 @@ describe('Variables Test Suite', function() {
             subChildren.body.variables.length,
             'There is a different number of grandchild variables than expected',
         ).to.equal(2);
-        utils.verifyVariable(subChildren.body.variables[0], 'a', 'int', '3');
-        utils.verifyVariable(subChildren.body.variables[1], 'b', 'int', '4');
+        verifyVariable(subChildren.body.variables[0], 'a', 'int', '3');
+        verifyVariable(subChildren.body.variables[1], 'b', 'int', '4');
         // set the variables to something different
         await dc.setVariableRequest({ name: 'a', value: '25', variablesReference: subChildVR });
         await dc.setVariableRequest({ name: 'b', value: '10', variablesReference: subChildVR });
@@ -151,17 +140,17 @@ describe('Variables Test Suite', function() {
             subChildren.body.variables.length,
             'There is a different number of grandchild variables than expected',
         ).to.equal(2);
-        utils.verifyVariable(subChildren.body.variables[0], 'a', 'int', '25');
-        utils.verifyVariable(subChildren.body.variables[1], 'b', 'int', '10');
+        verifyVariable(subChildren.body.variables[0], 'a', 'int', '25');
+        verifyVariable(subChildren.body.variables[1], 'b', 'int', '10');
         // step the program and see that the values were passed to the program and evaluated.
         await dc.nextRequest({ threadId: scope.threadId });
         await dc.nextRequest({ threadId: scope.threadId });
-        scope = await utils.getScopes(dc);
+        scope = await getScopes(dc);
         expect(scope.scopes.body.scopes.length, 'Unexpected number of scopes returned').to.equal(1);
         vr = scope.scopes.body.scopes[0].variablesReference;
         vars = await dc.variablesRequest({ variablesReference: vr });
         expect(vars.body.variables.length, 'There is a different number of variables than expected').to.equal(numVars);
-        utils.verifyVariable(vars.body.variables[5], 'e', 'int', '35');
+        verifyVariable(vars.body.variables[5], 'e', 'int', '35');
     });
 
     it('can read and set array elements in a program', async function() {
@@ -169,22 +158,22 @@ describe('Variables Test Suite', function() {
         const br = await dc.setBreakpointsRequest({ source: { path: varsSrc }, breakpoints: [{ line: 24 }] });
         expect(br.success).to.equal(true);
         await dc.continueRequest({ threadId: scope.threadId });
-        scope = await utils.getScopes(dc);
+        scope = await getScopes(dc);
         expect(scope.scopes.body.scopes.length, 'Unexpected number of scopes returned').to.equal(1);
         // assert we can see the array and its elements
         let vr = scope.scopes.body.scopes[0].variablesReference;
         let vars = await dc.variablesRequest({ variablesReference: vr });
         expect(vars.body.variables.length, 'There is a different number of variables than expected').to.equal(numVars);
-        utils.verifyVariable(vars.body.variables[6], 'f', 'int [3]', '[3]', true);
+        verifyVariable(vars.body.variables[6], 'f', 'int [3]', '[3]', true);
         const childVR = vars.body.variables[6].variablesReference;
         let children = await dc.variablesRequest({ variablesReference: childVR });
         expect(
             children.body.variables.length,
             'There is a different number of child variables than expected',
         ).to.equal(3);
-        utils.verifyVariable(children.body.variables[0], '[0]', 'int', '1');
-        utils.verifyVariable(children.body.variables[1], '[1]', 'int', '2');
-        utils.verifyVariable(children.body.variables[2], '[2]', 'int', '3');
+        verifyVariable(children.body.variables[0], '[0]', 'int', '1');
+        verifyVariable(children.body.variables[1], '[1]', 'int', '2');
+        verifyVariable(children.body.variables[2], '[2]', 'int', '3');
         // set the variables to something different
         await dc.setVariableRequest({ name: '[0]', value: '11', variablesReference: childVR });
         await dc.setVariableRequest({ name: '[1]', value: '22', variablesReference: childVR });
@@ -195,16 +184,16 @@ describe('Variables Test Suite', function() {
             children.body.variables.length,
             'There is a different number of child variables than expected',
         ).to.equal(3);
-        utils.verifyVariable(children.body.variables[0], '[0]', 'int', '11');
-        utils.verifyVariable(children.body.variables[1], '[1]', 'int', '22');
-        utils.verifyVariable(children.body.variables[2], '[2]', 'int', '33');
+        verifyVariable(children.body.variables[0], '[0]', 'int', '11');
+        verifyVariable(children.body.variables[1], '[1]', 'int', '22');
+        verifyVariable(children.body.variables[2], '[2]', 'int', '33');
         // step the program and see that the values were passed to the program and evaluated.
         await dc.nextRequest({ threadId: scope.threadId });
-        scope = await utils.getScopes(dc);
+        scope = await getScopes(dc);
         expect(scope.scopes.body.scopes.length, 'Unexpected number of scopes returned').to.equal(1);
         vr = scope.scopes.body.scopes[0].variablesReference;
         vars = await dc.variablesRequest({ variablesReference: vr });
         expect(vars.body.variables.length, 'There is a different number of variables than expected').to.equal(numVars);
-        utils.verifyVariable(vars.body.variables[7], 'g', 'int', '66');
+        verifyVariable(vars.body.variables[7], 'g', 'int', '66');
     });
 });

--- a/src/integration-tests/vars_cpp.spec.ts
+++ b/src/integration-tests/vars_cpp.spec.ts
@@ -9,35 +9,29 @@
  *********************************************************************/
 
 import { expect } from 'chai';
-import * as cp from 'child_process';
 import * as path from 'path';
 import { DebugClient } from 'vscode-debugadapter-testsupport';
-import * as utils from './utils';
+import {
+    compareVariable, getScopes, Scope, standardBefore, standardBeforeEach, testProgramsDir,
+    verifyVariable,
+} from './utils';
 
 // Allow non-arrow functions: https://mochajs.org/#arrow-functions
 // tslint:disable:only-arrow-functions
 
 let dc: DebugClient;
-let scope: utils.Scope;
+let scope: Scope;
 
-const testProgramsDir = path.join(__dirname, '..', '..', 'src', 'integration-tests', 'test-programs');
 const varsCppProgram = path.join(testProgramsDir, 'vars_cpp');
 const varsCppSrc = path.join(testProgramsDir, 'vars_cpp.cpp');
 
+before(standardBefore);
+
 beforeEach(async function() {
-    // Build the test program
-    cp.execSync('make', { cwd: testProgramsDir });
+    dc = await standardBeforeEach();
 
-    let args: string = path.join(__dirname, '..', 'debugAdapter.js');
-    if (process.env.INSPECT_DEBUG_ADAPTER) {
-        args = '--inspect-brk ' + args;
-    }
-
-    dc = new DebugClient('node', args, 'gdb');
-    await dc.start();
-    await dc.initializeRequest();
     await dc.hitBreakpoint({ verbose: true, program: varsCppProgram }, { path: varsCppSrc, line: 37 });
-    scope = await utils.getScopes(dc);
+    scope = await getScopes(dc);
     expect(scope.scopes.body.scopes.length, 'Unexpected number of scopes returned').to.equal(1);
 });
 
@@ -56,8 +50,8 @@ describe('Variables CPP Test Suite', function() {
         const vr = scope.scopes.body.scopes[0].variablesReference;
         const vars = await dc.variablesRequest({ variablesReference: vr });
         expect(vars.body.variables.length, 'There is a different number of variables than expected').to.equal(3);
-        utils.verifyVariable(vars.body.variables[0], 'fooA', 'Foo *', undefined, true);
-        utils.verifyVariable(vars.body.variables[1], 'fooB', 'Foo *', undefined, true);
+        verifyVariable(vars.body.variables[0], 'fooA', 'Foo *', undefined, true);
+        verifyVariable(vars.body.variables[1], 'fooB', 'Foo *', undefined, true);
         expect(vars.body.variables[0].value, 'Value of fooA matches fooB').to.not.equal(vars.body.variables[1].value);
         // check that the children names and values are the same, but values are different
         let childrenA = await dc.variablesRequest({ variablesReference: vars.body.variables[0].variablesReference });
@@ -66,21 +60,21 @@ describe('Variables CPP Test Suite', function() {
             childrenA.body.variables.length,
             'There is a different number of child variables than expected',
         ).to.equal(childrenB.body.variables.length);
-        utils.compareVariable(childrenA.body.variables[0], childrenB.body.variables[0], true, true, false);
-        utils.compareVariable(childrenA.body.variables[1], childrenB.body.variables[1], true, true, false);
-        utils.compareVariable(childrenA.body.variables[2], childrenB.body.variables[2], true, true, false);
+        compareVariable(childrenA.body.variables[0], childrenB.body.variables[0], true, true, false);
+        compareVariable(childrenA.body.variables[1], childrenB.body.variables[1], true, true, false);
+        compareVariable(childrenA.body.variables[2], childrenB.body.variables[2], true, true, false);
         // set fooA to be equal to fooB.
         await dc.setVariableRequest({ name: 'fooA', value: vars.body.variables[1].value, variablesReference: vr });
         // check types and value after the set
         const vars2 = await dc.variablesRequest({ variablesReference: vr });
         expect(vars2.body.variables.length, 'There is a different number of variables than expected').to.equal(3);
-        utils.compareVariable(vars2.body.variables[0], vars2.body.variables[1], false, true, true);
+        compareVariable(vars2.body.variables[0], vars2.body.variables[1], false, true, true);
         // check the objects are identical
         childrenA = await dc.variablesRequest({ variablesReference: vars2.body.variables[0].variablesReference });
         childrenB = await dc.variablesRequest({ variablesReference: vars2.body.variables[1].variablesReference });
-        utils.compareVariable(childrenA.body.variables[0], childrenB.body.variables[0], true, true, true);
-        utils.compareVariable(childrenA.body.variables[1], childrenB.body.variables[1], true, true, true);
-        utils.compareVariable(childrenA.body.variables[2], childrenB.body.variables[2], true, true, true);
+        compareVariable(childrenA.body.variables[0], childrenB.body.variables[0], true, true, true);
+        compareVariable(childrenA.body.variables[1], childrenB.body.variables[1], true, true, true);
+        compareVariable(childrenA.body.variables[2], childrenB.body.variables[2], true, true, true);
     });
 
     it('can read and set nested variables from a cpp object', async function() {
@@ -88,7 +82,7 @@ describe('Variables CPP Test Suite', function() {
         const vr = scope.scopes.body.scopes[0].variablesReference;
         const vars = await dc.variablesRequest({ variablesReference: vr });
         expect(vars.body.variables.length, 'There is a different number of variables than expected').to.equal(3);
-        utils.verifyVariable(vars.body.variables[0], 'fooA', 'Foo *', undefined, true);
+        verifyVariable(vars.body.variables[0], 'fooA', 'Foo *', undefined, true);
         expect(
             vars.body.variables[0].variablesReference,
             `${vars.body.variables[0].name} has no children`,
@@ -99,9 +93,9 @@ describe('Variables CPP Test Suite', function() {
             children.body.variables.length,
             'There is a different number of child variables than expected',
         ).to.equal(3);
-        utils.verifyVariable(children.body.variables[0], 'a', 'int', '1');
-        utils.verifyVariable(children.body.variables[1], 'c', 'char', '97 \'a\'');
-        utils.verifyVariable(children.body.variables[2], 'b', 'int', '2');
+        verifyVariable(children.body.variables[0], 'a', 'int', '1');
+        verifyVariable(children.body.variables[1], 'c', 'char', '97 \'a\'');
+        verifyVariable(children.body.variables[2], 'b', 'int', '2');
         // set child value
         await dc.setVariableRequest({
             name: children.body.variables[0].name,
@@ -114,9 +108,9 @@ describe('Variables CPP Test Suite', function() {
             children.body.variables.length,
             'There is a different number of child variables than expected',
         ).to.equal(3);
-        utils.verifyVariable(children.body.variables[0], 'a', 'int', '55');
+        verifyVariable(children.body.variables[0], 'a', 'int', '55');
         // these two values should be unchanged.
-        utils.verifyVariable(children.body.variables[1], 'c', 'char', '97 \'a\'');
-        utils.verifyVariable(children.body.variables[2], 'b', 'int', '2');
+        verifyVariable(children.body.variables[1], 'c', 'char', '97 \'a\'');
+        verifyVariable(children.body.variables[2], 'b', 'int', '2');
     });
 });


### PR DESCRIPTION
- Move the initialization code to a common function (standardBeforeEach)
- Move building the test programs to a common function, called only once
  per test file (standardBefore)
- Move testProgramsDir to a common location as well, since it is always
  the same

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>