### PR TITLE
Add function to resolve line tags in tests

### DIFF
--- a/src/integration-tests/test-programs/vars.c
+++ b/src/integration-tests/test-programs/vars.c
@@ -16,7 +16,7 @@ int main()
 {
     int a = 1;
     int b = 2;
-    int c = a + b;
+    int c = a + b; // STOP HERE
     struct foo r = {1, 2, {3, 4}};
     int d = r.x + r.y;
     int e = r.z.a + r.z.b;

--- a/src/integration-tests/test-programs/vars_cpp.cpp
+++ b/src/integration-tests/test-programs/vars_cpp.cpp
@@ -34,7 +34,7 @@ int main()
     Foo *fooA = new Foo(1, 2, 'a');
     Foo *fooB = new Foo(3, 4, 'b');
     Foo *fooarr[] = {fooA, fooB};
-    cout << "!!!Hello World!!!" << endl;
+    cout << "!!!Hello World!!!" << endl; // STOP HERE
     cout << "!!!Hello World Again!!!" << endl;
     return 0;
 }

--- a/src/integration-tests/var.spec.ts
+++ b/src/integration-tests/var.spec.ts
@@ -13,7 +13,8 @@ import * as path from 'path';
 import { LaunchRequestArguments } from '..';
 import { CdtDebugClient } from './debugClient';
 import {
-    gdbPath, getScopes, openGdbConsole, Scope, standardBefore, standardBeforeEach, testProgramsDir, verifyVariable,
+    gdbPath, getScopes, openGdbConsole, resolveLineTagLocations, Scope, standardBefore, standardBeforeEach,
+    testProgramsDir, verifyVariable,
 } from './utils';
 
 // Allow non-arrow functions: https://mochajs.org/#arrow-functions
@@ -25,7 +26,15 @@ const varsProgram = path.join(testProgramsDir, 'vars');
 const varsSrc = path.join(testProgramsDir, 'vars.c');
 const numVars = 8; // number of variables in the main() scope of vars.c
 
-before(standardBefore);
+const lineTags = {
+    'STOP HERE': 0,
+};
+
+before(function() {
+    standardBefore();
+
+    resolveLineTagLocations(varsSrc, lineTags);
+});
 
 beforeEach(async function() {
     dc = await standardBeforeEach();
@@ -36,9 +45,9 @@ beforeEach(async function() {
         program: varsProgram,
         openGdbConsole,
     } as LaunchRequestArguments, {
-        path: varsSrc,
-        line: 19,
-    });
+            path: varsSrc,
+            line: lineTags['STOP HERE'],
+        });
     scope = await getScopes(dc);
     expect(scope.scopes.body.scopes.length, 'Unexpected number of scopes returned').to.equal(1);
 });

--- a/src/integration-tests/vars_cpp.spec.ts
+++ b/src/integration-tests/vars_cpp.spec.ts
@@ -13,8 +13,8 @@ import * as path from 'path';
 import { LaunchRequestArguments } from '..';
 import { CdtDebugClient } from './debugClient';
 import {
-    compareVariable, gdbPath, getScopes, openGdbConsole, Scope, standardBefore, standardBeforeEach, testProgramsDir,
-    verifyVariable,
+    compareVariable, gdbPath, getScopes, openGdbConsole, resolveLineTagLocations, Scope, standardBefore,
+    standardBeforeEach, testProgramsDir, verifyVariable,
 } from './utils';
 
 // Allow non-arrow functions: https://mochajs.org/#arrow-functions
@@ -26,7 +26,15 @@ let scope: Scope;
 const varsCppProgram = path.join(testProgramsDir, 'vars_cpp');
 const varsCppSrc = path.join(testProgramsDir, 'vars_cpp.cpp');
 
-before(standardBefore);
+const lineTags = {
+    'STOP HERE': 0,
+};
+
+before(function() {
+    standardBefore();
+
+    resolveLineTagLocations(varsCppSrc, lineTags);
+});
 
 beforeEach(async function() {
     dc = await standardBeforeEach();
@@ -37,9 +45,9 @@ beforeEach(async function() {
         program: varsCppProgram,
         openGdbConsole,
     } as LaunchRequestArguments, {
-        path: varsCppSrc,
-        line: 37,
-    });
+            path: varsCppSrc,
+            line: lineTags['STOP HERE'],
+        });
     scope = await getScopes(dc);
     expect(scope.scopes.body.scopes.length, 'Unexpected number of scopes returned').to.equal(1);
 });


### PR DESCRIPTION
Hard-coding line numbers in tests makes them quite fragil and hard to
modify.  This patch allows us to place tags in test source files, and
then get the source line number corresponding to a tag.  This makes it
possible to modify the test source file without having to change all the
hard-coded line numbers.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>