### PR TITLE
Add support for arbritrary address expressions in memory read requests

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -53,6 +53,11 @@ export interface ObjectVariableReference {
 
 export type VariableReference = FrameVariableReference | ObjectVariableReference;
 
+export interface MemoryRequestArguments {
+    address: string;
+    length: number;
+}
+
 /**
  * Response for our custom 'cdt-gdb-adapter/Memory' request.
  */
@@ -518,15 +523,17 @@ export class GDBDebugSession extends LoggingDebugSession {
      */
     protected async memoryRequest(response: MemoryResponse, args: any) {
         try {
-            if (typeof (args.address) !== 'number') {
-                throw new Error(`Invalid type for 'address', expected number, got ${typeof (args.address)}`);
+            if (typeof (args.address) !== 'string') {
+                throw new Error(`Invalid type for 'address', expected string, got ${typeof (args.address)}`);
             }
 
             if (typeof (args.length) !== 'number') {
                 throw new Error(`Invalid type for 'length', expected number, got ${typeof (args.length)}`);
             }
 
-            const result = await sendDataReadMemoryBytes(this.gdb, args.address, args.length);
+            const typedArgs = args as MemoryRequestArguments;
+
+            const result = await sendDataReadMemoryBytes(this.gdb, typedArgs.address, typedArgs.length);
             response.body = {
                 data: result.memory[0].contents,
             };

--- a/src/integration-tests/mem.spec.ts
+++ b/src/integration-tests/mem.spec.ts
@@ -58,8 +58,30 @@ describe('Memory Test Suite', function() {
             }
         }
 
-        const mem = (await dc.send('cdt-gdb-adapter/Memory', {
-            address: addr,
+        // Read using
+        let mem = (await dc.send('cdt-gdb-adapter/Memory', {
+            address: addr.toString(10),
+            length: 10,
+        })) as MemoryResponse;
+
+        expect(mem.body.data).eq('f1efd4fd7248450c2d13');
+
+        mem = (await dc.send('cdt-gdb-adapter/Memory', {
+            address: `0x${addr.toString(16)}`,
+            length: 10,
+        })) as MemoryResponse;
+
+        expect(mem.body.data).eq('f1efd4fd7248450c2d13');
+
+        mem = (await dc.send('cdt-gdb-adapter/Memory', {
+            address: '&array[3 + 2]',
+            length: 10,
+        })) as MemoryResponse;
+
+        expect(mem.body.data).eq('48450c2d1374d6f612dc');
+
+        mem = (await dc.send('cdt-gdb-adapter/Memory', {
+            address: 'parray',
             length: 10,
         })) as MemoryResponse;
 
@@ -69,7 +91,7 @@ describe('Memory Test Suite', function() {
     it('handles unable to read memory', async function() {
         // This test will only work for targets for which address 0 is not readable, which is good enough for now.
         const err = await expectRejection(dc.send('cdt-gdb-adapter/Memory', {
-            address: 0,
+            address: '0',
             length: 10,
         }));
         expect(err.message).contains('Unable to read memory');

--- a/src/mi/data.ts
+++ b/src/mi/data.ts
@@ -19,8 +19,8 @@ interface MIDataReadMemoryBytesResponse {
     }>;
 }
 
-export function sendDataReadMemoryBytes(gdb: GDBBackend, address: number, size: number)
+export function sendDataReadMemoryBytes(gdb: GDBBackend, address: string, size: number)
     : Promise<MIDataReadMemoryBytesResponse> {
-    const command = `-data-read-memory-bytes 0x${address.toString(16)} ${size}`;
+    const command = `-data-read-memory-bytes "${address}" ${size}`;
     return gdb.sendCommand(command);
 }


### PR DESCRIPTION
Currently, it's only possible to pass a number for the address from
which we want to read memory, in our cdt-gdb-adapter/Memory request.  It
can be useful for the user to type expressions that resolve to an
address, such as "&myVariable" or "myPointer".  By accepting these
expressions (and forwarding them directly to GDB), we allow frontends to
pass directly what the user types in.

This indirectly fixes #66, where we wouldn't support full 64 bits
addresses (because node's integers are 53 bits).  We bypass it, since
all expressions would now be passed as strings, even literal addresses.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>