### PR TITLE
Send address in reply to cdt-gdb-adapter/Memory

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -65,6 +65,7 @@ export interface MemoryResponse extends Response {
     body: {
         /* Hex-encoded string of bytes.  */
         data: string;
+        address: string;
     };
 }
 
@@ -525,6 +526,7 @@ export class GDBDebugSession extends LoggingDebugSession {
             const result = await sendDataReadMemoryBytes(this.gdb, typedArgs.address, typedArgs.length);
             response.body = {
                 data: result.memory[0].contents,
+                address: result.memory[0].begin,
             };
             this.sendResponse(response);
         } catch (err) {

--- a/src/mi/data.ts
+++ b/src/mi/data.ts
@@ -12,9 +12,9 @@ import { GDBBackend } from '../GDBBackend';
 
 interface MIDataReadMemoryBytesResponse {
     memory: Array<{
-        begin: number;
-        end: number;
-        offset: number;
+        begin: string;
+        end: string;
+        offset: string;
         contents: string;
     }>;
 }


### PR DESCRIPTION
Now that we can read memory using arbitrary expressions (e.g.
&myVariable), I think it would be useful to send back the address of the
read memory to the client.  When issuing a memory read for &myVariable,
the client won't know at what address we are reading, but will probably
want to display the address, if the goal of that request is to populate
a memory view.

Since, in theory, addresses can be 64-bits long, I decided to transmit
addresses as hexadecimal strings (with the leading 0x).  Otherwise, if
we sent the address as a number, clients based on nodejs (and even us,
who are running on nodejs) would have some truncation problems since the
nodejs number data type is 53-bits long.  At the moment, we don't need
to interpret the address in cdt-gdb-adapter, so I chose to just forward
what we receive from GDB to the client.

For the tests, I do convert addresses to numbers because in practice,
with x86-64, addresses are 48-bits long, so we are fine, and we can
always change it later.  For the protocol itself, we will have less
opportunities to change it as time passes, so better do it right the
first time.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>