### PR TITLE
Publish binding.gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "chai": "^4.2.0",
     "mocha": "^5.2.0",
     "mocha-jenkins-reporter": "^0.4.1",
+    "node-gyp": "^3.8.0",
     "ts-loader": "^5.3.0",
     "tslint": "^5.11.0",
     "tslint-language-service": "^0.9.9",
@@ -40,6 +41,7 @@
     "webpack-cli": "^3.1.2"
   },
   "files": [
+    "binding.gyp",
     "dist/**/*.js",
     "dist/**/*.js.map",
     "dist/**/*.d.ts",


### PR DESCRIPTION
We are not publishing the binaries built from native code, but one might
want to actually build it. For that, `binding.gyp` is required.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>

---

I am sorry again, it seems like it would require this file too in order to be able to build everything.
I cannot think about anything else we would be missing, doesn't mean I didn't miss something...

Conversion to N-API is following.

Note that this commit explicitly adds a dev dependency on `node-gyp`, it worked before, but I feel more comfortable having it explicitly defined?