### PR TITLE
Break out the MemoryContents from the response

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -64,12 +64,14 @@ export interface MemoryRequestArguments {
 /**
  * Response for our custom 'cdt-gdb-adapter/Memory' request.
  */
+export interface MemoryContents {
+    /* Hex-encoded string of bytes.  */
+    data: string;
+    address: string;
+}
+
 export interface MemoryResponse extends Response {
-    body: {
-        /* Hex-encoded string of bytes.  */
-        data: string;
-        address: string;
-    };
+    body: MemoryContents;
 }
 
 export class GDBDebugSession extends LoggingDebugSession {


### PR DESCRIPTION
The client only gets the body field so need a type.