### PR TITLE
Stow away the logger to make sure subclasses use the same one.

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -13,7 +13,7 @@ import {
     Handles, InitializedEvent, Logger, logger, LoggingDebugSession, OutputEvent, Response, Scope, Source,
     StackFrame, StoppedEvent, TerminatedEvent, Thread,
 } from 'vscode-debugadapter';
-import { DebugProtocol } from 'vscode-debugprotocol/lib/debugProtocol';
+import { DebugProtocol } from 'vscode-debugprotocol';
 import { GDBBackend } from './GDBBackend';
 import * as mi from './mi';
 import { sendDataReadMemoryBytes } from './mi/data';

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -9,11 +9,10 @@
  *********************************************************************/
 import * as os from 'os';
 import * as path from 'path';
-import { logger } from 'vscode-debugadapter/lib/logger';
 import {
-    Handles, InitializedEvent, Logger, LoggingDebugSession, OutputEvent, Response, Scope, Source,
+    Handles, InitializedEvent, Logger, logger, LoggingDebugSession, OutputEvent, Response, Scope, Source,
     StackFrame, StoppedEvent, TerminatedEvent, Thread,
-} from 'vscode-debugadapter/lib/main';
+} from 'vscode-debugadapter';
 import { DebugProtocol } from 'vscode-debugprotocol/lib/debugProtocol';
 import { GDBBackend } from './GDBBackend';
 import * as mi from './mi';
@@ -82,11 +81,15 @@ export class GDBDebugSession extends LoggingDebugSession {
     protected supportsRunInTerminalRequest = false;
     protected supportsGdbConsole = false;
 
+    /* A reference to the logger to be used by subclasses */
+    protected logger: Logger.Logger;
+
     private frameHandles = new Handles<FrameReference>();
     private variableHandles = new Handles<VariableReference>();
 
     constructor() {
         super();
+        this.logger = logger;
     }
 
     protected createBackend(): GDBBackend {


### PR DESCRIPTION
In our plugin that extends the cdt adapter, we found that we were
unable to access the same logger that this extension was using.
It seemed to create a second logger. That made it hard to properly
set up the logging level. This stows a reference to it in the parent
making it accessible by extensions.

Also cleans up the imports for the logger and everything else in the
vscode-debugadapter.