### PR TITLE
Add offset member to memory request

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -58,6 +58,7 @@ export type VariableReference = FrameVariableReference | ObjectVariableReference
 export interface MemoryRequestArguments {
     address: string;
     length: number;
+    offset?: number;
 }
 
 /**
@@ -570,9 +571,14 @@ export class GDBDebugSession extends LoggingDebugSession {
                 throw new Error(`Invalid type for 'length', expected number, got ${typeof (args.length)}`);
             }
 
+            if (typeof (args.offset) !== 'number' && typeof (args.offset) !== 'undefined') {
+                throw new Error(`Invalid type for 'offset', expected number or undefined, got ${typeof (args.offset)}`);
+            }
+
             const typedArgs = args as MemoryRequestArguments;
 
-            const result = await sendDataReadMemoryBytes(this.gdb, typedArgs.address, typedArgs.length);
+            const result = await sendDataReadMemoryBytes(
+                this.gdb, typedArgs.address, typedArgs.length, typedArgs.offset);
             response.body = {
                 data: result.memory[0].contents,
                 address: result.memory[0].begin,

--- a/src/mi/data.ts
+++ b/src/mi/data.ts
@@ -19,8 +19,7 @@ interface MIDataReadMemoryBytesResponse {
     }>;
 }
 
-export function sendDataReadMemoryBytes(gdb: GDBBackend, address: string, size: number)
+export function sendDataReadMemoryBytes(gdb: GDBBackend, address: string, size: number, offset: number = 0)
     : Promise<MIDataReadMemoryBytesResponse> {
-    const command = `-data-read-memory-bytes "${address}" ${size}`;
-    return gdb.sendCommand(command);
+    return gdb.sendCommand(`-data-read-memory-bytes -o ${offset} "${address}" ${size}`);
 }


### PR DESCRIPTION
This allows clients to easily move around some location that would be
resolved by GDB.

Because the offset is in bytes, it avoids issues such as doing `&i +
offset` were in this case pointer arithmetics would be involved, making
jumps of several bytes at once according to the pointer type.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>