### PR TITLE
Add handling for stopped by signal.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "type": "node",
       "request": "launch",
       "name": "Mocha All",
-      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "program": "${workspaceFolder}/node_modules/.bin/mocha",
       "args": [
         "--timeout",
         "999999",
@@ -19,7 +19,7 @@
       "type": "node",
       "request": "launch",
       "name": "Mocha Current File",
-      "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+      "program": "${workspaceFolder}/node_modules/.bin/mocha",
       "args": [
         "--timeout",
         "999999",

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -618,6 +618,10 @@ export class GDBDebugSession extends LoggingDebugSession {
             case 'end-stepping-range':
                 this.sendStoppedEvent('step', parseInt(result['thread-id'], 10));
                 break;
+            case 'signal-received':
+                const name = result['signal-name'] || 'signal';
+                this.sendStoppedEvent(name, parseInt(result['thread-id'], 10));
+                break;
             default:
                 logger.warn('GDB unhandled stop: ' + JSON.stringify(result));
         }

--- a/src/integration-tests/stop.spec.ts
+++ b/src/integration-tests/stop.spec.ts
@@ -1,0 +1,40 @@
+/*********************************************************************
+ * Copyright (c) 2018 QNX Software Systems and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+import { CdtDebugClient } from './debugClient';
+import { standardBefore, standardBeforeEach, gdbPath, testProgramsDir, openGdbConsole } from './utils';
+import { LaunchRequestArguments } from '../GDBDebugSession';
+import { expect } from 'chai';
+import * as path from 'path';
+
+let dc: CdtDebugClient;
+
+before(standardBefore);
+
+beforeEach(async () => {
+    dc = await standardBeforeEach();
+});
+
+afterEach(async () => {
+    await dc.stop();
+});
+
+describe('stop', async () => {
+    it('handles segv', async () => {
+        await dc.launchRequest({
+            verbose: true,
+            gdb: gdbPath,
+            program: path.join(testProgramsDir, 'segv'),
+            openGdbConsole,
+        } as LaunchRequestArguments);
+        await dc.configurationDoneRequest();
+        const stoppedEvent = await dc.waitForEvent('stopped');
+        expect(stoppedEvent.body.reason).to.eq('SIGSEGV');
+    });
+});

--- a/src/integration-tests/test-programs/.gitignore
+++ b/src/integration-tests/test-programs/.gitignore
@@ -2,6 +2,7 @@ empty
 evaluate
 mem
 vars
+segv
 *.o
 .vscode
 /vars_cpp

--- a/src/integration-tests/test-programs/Makefile
+++ b/src/integration-tests/test-programs/Makefile
@@ -1,4 +1,4 @@
-BINS = empty evaluate vars vars_cpp mem
+BINS = empty evaluate vars vars_cpp mem segv
 
 .PHONY: all
 all: $(BINS)
@@ -22,6 +22,9 @@ vars: vars.o
 
 vars_cpp: vars_cpp.o
 	$(LINK_CXX)
+
+segv: segv.o
+	$(LINK)
 
 %.o: %.c
 	$(CC) -c $< -g3 -O0

--- a/src/integration-tests/test-programs/segv.c
+++ b/src/integration-tests/test-programs/segv.c
@@ -1,0 +1,7 @@
+int foo(int *addr) {
+    return *addr;
+}
+
+int main() {
+    foo(0);
+}

--- a/tslint.json
+++ b/tslint.json
@@ -13,6 +13,7 @@
     "interface-name": false,
     "no-empty-interface": false,
     "object-literal-sort-keys": false,
+    "ordered-imports": false,
     "quotemark": [
       true,
       "single",


### PR DESCRIPTION
Use the signal name as the stop reason if it's available. Doesn't seem to be any semantics behind that name. In VS Code, it shows up as the stop reason in the Call Stack view (e.g., PAUSED ON SIGSEGV)