### PR TITLE
Display address of array entry in Variables View

### DIFF
--- a/src/GDBBackend.ts
+++ b/src/GDBBackend.ts
@@ -27,6 +27,10 @@ export interface MIGDBShowResponse extends MIResponse {
     value?: string;
 }
 
+export interface MIGDBDataEvaluateExpressionResponse extends MIResponse {
+    value?: string;
+}
+
 export declare interface GDBBackend {
     on(event: 'consoleStreamOutput', listener: (output: string, category: string) => void): this;
     on(event: 'async', listener: (result: any) => void): this;
@@ -102,6 +106,10 @@ export class GDBBackend extends events.EventEmitter {
 
     public sendFileExecAndSymbols(program: string) {
         return this.sendCommand(`-file-exec-and-symbols ${program}`);
+    }
+
+    public sendDataEvaluateExpression(expr: string): Promise<MIGDBDataEvaluateExpressionResponse> {
+        return this.sendCommand(`-data-evaluate-expression "${expr}"`);
     }
 
     public sendGDBSet(params: string) {

--- a/src/GDBBackend.ts
+++ b/src/GDBBackend.ts
@@ -27,10 +27,6 @@ export interface MIGDBShowResponse extends MIResponse {
     value?: string;
 }
 
-export interface MIGDBDataEvaluateExpressionResponse extends MIResponse {
-    value?: string;
-}
-
 export declare interface GDBBackend {
     on(event: 'consoleStreamOutput', listener: (output: string, category: string) => void): this;
     on(event: 'async', listener: (result: any) => void): this;
@@ -106,10 +102,6 @@ export class GDBBackend extends events.EventEmitter {
 
     public sendFileExecAndSymbols(program: string) {
         return this.sendCommand(`-file-exec-and-symbols ${program}`);
-    }
-
-    public sendDataEvaluateExpression(expr: string): Promise<MIGDBDataEvaluateExpressionResponse> {
-        return this.sendCommand(`-data-evaluate-expression "${expr}"`);
     }
 
     public sendGDBSet(params: string) {

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -74,6 +74,9 @@ export interface MemoryResponse extends Response {
     body: MemoryContents;
 }
 
+const arrayRegex = /.*\[[\d]+\].*/;
+const arrayChildRegex = /[\d]+/;
+
 export class GDBDebugSession extends LoggingDebugSession {
     protected gdb: GDBBackend = this.createBackend();
     protected isAttach = false;
@@ -690,11 +693,16 @@ export class GDBDebugSession extends LoggingDebugSession {
                         // value hasn't updated but it's still in scope
                         numVars++;
                     }
-                    // only push entries to the array that aren't being deleted
+                    // only push entries to the result that aren't being deleted
                     if (pushVar) {
+                        let value = varobj.value;
+                        // if we have an array parent entry, we need to display the address.
+                        if (arrayRegex.test(varobj.type)) {
+                            value = await this.getAddr(varobj);
+                        }
                         variables.push({
                             name: varobj.expression,
-                            value: varobj.value,
+                            value,
                             type: varobj.type,
                             variablesReference: parseInt(varobj.numchild, 10) > 0
                                 ? this.variableHandles.create({
@@ -733,9 +741,14 @@ export class GDBDebugSession extends LoggingDebugSession {
                     varobj = await varMgr.updateVar(this.gdb, frame.frameId, frame.threadId, depth, varobj);
                     varobj.isVar = true;
                 }
+                let value = varobj.value;
+                // if we have an array parent entry, we need to display the address.
+                if (arrayRegex.test(varobj.type)) {
+                    value = await this.getAddr(varobj);
+                }
                 variables.push({
                     name: varobj.expression,
-                    value: varobj.value,
+                    value,
                     type: varobj.type,
                     variablesReference: parseInt(varobj.numchild, 10) > 0
                         ? this.variableHandles.create({
@@ -812,8 +825,7 @@ export class GDBDebugSession extends LoggingDebugSession {
                 // check if we're dealing with an array
                 let name = `${ref.varobjName}.${child.exp}`;
                 let varobjName = name;
-                const arrayRegex = /.*\[[\d]+\].*/g;
-                const arrayChildRegex = /[\d]+/g;
+                let value = child.value ? child.value : child.type;
                 const isArrayParent = arrayRegex.test(child.type);
                 const isArrayChild = (varobj !== undefined
                     ? arrayRegex.test(varobj.type) && arrayChildRegex.test(child.exp)
@@ -839,13 +851,17 @@ export class GDBDebugSession extends LoggingDebugSession {
                         arrobj = await varMgr.updateVar(this.gdb, frame.frameId, frame.threadId, depth,
                             arrobj);
                     }
+                    // if we have an array parent entry, we need to display the address.
+                    if (isArrayParent) {
+                        value = await this.getAddr(arrobj);
+                    }
                     arrobj.isChild = true;
                     varobjName = arrobj.varname;
                 }
                 const variableName = isArrayChild ? name : child.exp;
                 variables.push({
                     name: variableName,
-                    value: child.value ? child.value : child.type,
+                    value,
                     type: child.type,
                     variablesReference: parseInt(child.numchild, 10) > 0
                         ? this.variableHandles.create({
@@ -858,6 +874,11 @@ export class GDBDebugSession extends LoggingDebugSession {
             }
         }
         return Promise.resolve(variables);
+    }
+
+    private async getAddr(varobj: varMgr.VarObjType) {
+        const addr = await this.gdb.sendDataEvaluateExpression(`&(${varobj.expression})`);
+        return addr.value ? addr.value : varobj.value;
     }
 
     private isChildOfClass(child: mi.MIVarChild): boolean {

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -877,7 +877,7 @@ export class GDBDebugSession extends LoggingDebugSession {
     }
 
     private async getAddr(varobj: varMgr.VarObjType) {
-        const addr = await this.gdb.sendDataEvaluateExpression(`&(${varobj.expression})`);
+        const addr = await mi.sendDataEvaluateExpression(this.gdb, `&(${varobj.expression})`);
         return addr.value ? addr.value : varobj.value;
     }
 

--- a/src/integration-tests/var.spec.ts
+++ b/src/integration-tests/var.spec.ts
@@ -30,6 +30,8 @@ const lineTags = {
     'STOP HERE': 0,
 };
 
+const hexValueRegex = /0x[\d]+/;
+
 before(function() {
     standardBefore();
 
@@ -184,7 +186,9 @@ describe('Variables Test Suite', function() {
         let vr = scope.scopes.body.scopes[0].variablesReference;
         let vars = await dc.variablesRequest({ variablesReference: vr });
         expect(vars.body.variables.length, 'There is a different number of variables than expected').to.equal(numVars);
-        verifyVariable(vars.body.variables[6], 'f', 'int [3]', '[3]', true);
+        verifyVariable(vars.body.variables[6], 'f', 'int [3]', undefined, true);
+        expect(hexValueRegex.test(vars.body.variables[6].value),
+            'The display value of the array is not a hexidecimal address').to.equal(true);
         const childVR = vars.body.variables[6].variablesReference;
         let children = await dc.variablesRequest({ variablesReference: childVR });
         expect(

--- a/src/mi/data.ts
+++ b/src/mi/data.ts
@@ -9,6 +9,7 @@
  *********************************************************************/
 
 import { GDBBackend } from '../GDBBackend';
+import { MIResponse } from './base';
 
 interface MIDataReadMemoryBytesResponse {
     memory: Array<{
@@ -19,7 +20,16 @@ interface MIDataReadMemoryBytesResponse {
     }>;
 }
 
+export interface MIGDBDataEvaluateExpressionResponse extends MIResponse {
+    value?: string;
+}
+
 export function sendDataReadMemoryBytes(gdb: GDBBackend, address: string, size: number, offset: number = 0)
     : Promise<MIDataReadMemoryBytesResponse> {
     return gdb.sendCommand(`-data-read-memory-bytes -o ${offset} "${address}" ${size}`);
+}
+
+export function sendDataEvaluateExpression(gdb: GDBBackend, expr: string)
+    : Promise<MIGDBDataEvaluateExpressionResponse> {
+    return gdb.sendCommand(`-data-evaluate-expression "${expr}"`);
 }

--- a/src/mi/index.ts
+++ b/src/mi/index.ts
@@ -9,6 +9,7 @@
  *********************************************************************/
 export * from './base';
 export * from './breakpoint';
+export * from './data';
 export * from './exec';
 export * from './stack';
 export * from './target';


### PR DESCRIPTION
Issue #26 - Show the address of the array rather than the size in square
brackets, as is done in Eclipse CDT.

Signed-off-by: Jonathan Williams <jonwilliams@blackberry.com>