### PR TITLE
Add handling of thread-created notify messages.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,19 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Server",
+      "cwd": "${workspaceFolder}",
+      "program": "${workspaceFolder}/dist/debugAdapter.js",
+      "args": [
+        "--server=4711"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/dist/**/*.js"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Mocha All",
       "program": "${workspaceFolder}/node_modules/.bin/mocha",
       "args": [


### PR DESCRIPTION
After configurationDone, vscode sends us a threads request.
However, since we're running, our request to get the threads
info from gdb doesn't respond. That's all fine if we have a
breakpoint since the threads request will resolve itself when
the breakpoint is hit. If not, the session hangs.

This change adds handling for notify messages and thread
creation in particular. We store away the threads from the
notifies and return that if we get a threads request while
running.

Also clean up the API to separate out the result/async class
from the data.

Also added a Server launch so we can debug the adapter.