### PR TITLE
Make Native Pty optional

### DIFF
--- a/src/GDBBackend.ts
+++ b/src/GDBBackend.ts
@@ -14,7 +14,6 @@ import { logger } from 'vscode-debugadapter/lib/logger';
 import { AttachRequestArguments, LaunchRequestArguments } from './GDBDebugSession';
 import { MIResponse } from './mi';
 import { MIParser } from './MIParser';
-import { Pty } from './native/pty';
 
 export interface MIExecNextRequest {
     reverse?: boolean;
@@ -51,6 +50,9 @@ export class GDBBackend extends events.EventEmitter {
     public async spawnInClientTerminal(args: LaunchRequestArguments | AttachRequestArguments,
         cb: (args: string[]) => Promise<void>) {
         const gdb = args.gdb ? args.gdb : 'gdb';
+        // Use dynamic import to remove need for natively building this adapter
+        // Useful when 'spawnInClientTerminal' isn't needed, but adapter is distributed on multiple OS's
+        const { Pty } = await import('./native/pty');
         const pty = new Pty();
         await cb([gdb, '-ex', `new-ui mi2 ${pty.name}`]);
         this.out = pty.master;


### PR DESCRIPTION
With our usage of this adapter, we have no need for `spawnInClientTerminal`.

However, there is a hard dependency for this on native `pty` code.

This makes the package difficult to distribute in built form as it has to be built for every target platform (Linux, Windows, MacOS, etc.).

This PR switches `Pty` to be a [dynamic import](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-4.html) so it's only required when needed by `spawnInClientTerminal`.

This allows the adapter to be distributed as pure JavaScript as long as `spawnInClientTerminal` isn't used.