### PR TITLE
Add request option for gdb client arguments

### DIFF
--- a/src/GDBBackend.ts
+++ b/src/GDBBackend.ts
@@ -42,7 +42,11 @@ export class GDBBackend extends events.EventEmitter {
 
     public spawn(args: LaunchRequestArguments | AttachRequestArguments) {
         const gdb = args.gdb ? args.gdb : 'gdb';
-        this.proc = spawn(gdb, ['--interpreter=mi2']);
+        let options = ['--interpreter=mi2'];
+        if (args.gdbArguments) {
+            options = options.concat(args.gdbArguments);
+        }
+        this.proc = spawn(gdb, options);
         this.out = this.proc.stdin;
         return this.parser.parse(this.proc.stdout);
     }

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -19,22 +19,21 @@ import * as mi from './mi';
 import { sendDataReadMemoryBytes } from './mi/data';
 import * as varMgr from './varManager';
 
-export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
+export interface RequestArguments extends DebugProtocol.LaunchRequestArguments {
     gdb?: string;
+    gdbArguments?: string[];
     program: string;
-    arguments?: string;
     verbose?: boolean;
     logFile?: string;
     openGdbConsole?: boolean;
 }
 
-export interface AttachRequestArguments extends DebugProtocol.LaunchRequestArguments {
-    gdb?: string;
-    program: string;
+export interface LaunchRequestArguments extends RequestArguments {
+    arguments?: string;
+}
+
+export interface AttachRequestArguments extends RequestArguments {
     processId: string;
-    verbose?: boolean;
-    logFile?: string;
-    openGdbConsole?: boolean;
 }
 
 export interface FrameReference {


### PR DESCRIPTION
This PR adds support for passing optional arguments to the gdb client launch command.

There are a few other arguments I plan on adding, so will update the [adapter config](https://github.com/eclipse-cdt/cdt-gdb-vscode/blob/master/package.json#L47) in one go once any changes are merged here.

The PR also refactors the request argument interfaces slightly so common arguments are shared for easier maintenance.