### PR TITLE
Add optional initialisation commands

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -139,6 +139,7 @@ export class GDBDebugSession extends LoggingDebugSession {
 
             await this.spawn(args);
             await this.gdb.sendFileExecAndSymbols(args.program);
+            await this.gdb.sendEnablePrettyPrint();
 
             await mi.sendTargetAttachRequest(this.gdb, { pid: args.processId });
             this.sendEvent(new OutputEvent(`attached to process ${args.processId}`));
@@ -169,7 +170,6 @@ export class GDBDebugSession extends LoggingDebugSession {
 
             await this.spawn(args);
             await this.gdb.sendFileExecAndSymbols(args.program);
-
             await this.gdb.sendEnablePrettyPrint();
 
             if (args.initCommands) {

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -19,22 +19,21 @@ import * as mi from './mi';
 import { sendDataReadMemoryBytes } from './mi/data';
 import * as varMgr from './varManager';
 
-export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArguments {
+export interface RequestArguments extends DebugProtocol.LaunchRequestArguments {
     gdb?: string;
     program: string;
-    arguments?: string;
     verbose?: boolean;
     logFile?: string;
     openGdbConsole?: boolean;
+    initCommands?: string[];
 }
 
-export interface AttachRequestArguments extends DebugProtocol.LaunchRequestArguments {
-    gdb?: string;
-    program: string;
+export interface LaunchRequestArguments extends RequestArguments {
+    arguments?: string;
+}
+
+export interface AttachRequestArguments extends RequestArguments {
     processId: string;
-    verbose?: boolean;
-    logFile?: string;
-    openGdbConsole?: boolean;
 }
 
 export interface FrameReference {
@@ -144,6 +143,12 @@ export class GDBDebugSession extends LoggingDebugSession {
             await mi.sendTargetAttachRequest(this.gdb, { pid: args.processId });
             this.sendEvent(new OutputEvent(`attached to process ${args.processId}`));
 
+            if (args.initCommands) {
+                for (const command of args.initCommands) {
+                    await this.gdb.sendCommand(command);
+                }
+            }
+
             this.sendEvent(new InitializedEvent());
             this.sendResponse(response);
         } catch (err) {
@@ -165,7 +170,13 @@ export class GDBDebugSession extends LoggingDebugSession {
             await this.spawn(args);
             await this.gdb.sendFileExecAndSymbols(args.program);
 
-            this.gdb.sendEnablePrettyPrint();
+            await this.gdb.sendEnablePrettyPrint();
+
+            if (args.initCommands) {
+                for (const command of args.initCommands) {
+                    await this.gdb.sendCommand(command);
+                }
+            }
 
             if (args.arguments) {
                 await mi.sendExecArguments(this.gdb, { arguments: args.arguments });


### PR DESCRIPTION
Building on #106, this PR allows the user to pass optional initialisation commands to be run by gdb once ready.

This allows immediate control/setup commands such as target download `-target-download` or run-to-main `-break-insert -t --function main`