### PR TITLE
Add support for attaching to a remote gdb server

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558 
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "watch",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/src/GDBBackend.ts
+++ b/src/GDBBackend.ts
@@ -126,6 +126,10 @@ export class GDBBackend extends events.EventEmitter {
         return this.sendCommand('-gdb-exit');
     }
 
+    public sendTargetSelectRemote(remote: string) {
+        return this.sendCommand(`-target-select remote ${remote}`);
+    }
+
     private nextToken() {
         return this.token++;
     }

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -21,10 +21,12 @@ import * as varMgr from './varManager';
 
 export interface RequestArguments extends DebugProtocol.LaunchRequestArguments {
     gdb?: string;
+    gdbArguments?: string[];
     program: string;
     verbose?: boolean;
     logFile?: string;
     openGdbConsole?: boolean;
+    initCommands?: string[];
 }
 
 export interface LaunchRequestArguments extends RequestArguments {
@@ -157,6 +159,12 @@ export class GDBDebugSession extends LoggingDebugSession {
                 await this.gdb.sendTargetSelectRemote(args.remote);
             }
 
+            if (args.initCommands) {
+                for (const command of args.initCommands) {
+                    await this.gdb.sendCommand(command);
+                }
+            }
+
             this.sendEvent(new InitializedEvent());
             this.sendResponse(response);
         } catch (err) {
@@ -179,6 +187,12 @@ export class GDBDebugSession extends LoggingDebugSession {
             await this.gdb.sendFileExecAndSymbols(args.program);
 
             this.gdb.sendEnablePrettyPrint();
+
+            if (args.initCommands) {
+                for (const command of args.initCommands) {
+                    await this.gdb.sendCommand(command);
+                }
+            }
 
             if (args.arguments) {
                 await mi.sendExecArguments(this.gdb, { arguments: args.arguments });

--- a/src/native/pty.cc
+++ b/src/native/pty.cc
@@ -78,9 +78,9 @@ static Napi::Value create_pty(const Napi::CallbackInfo &info) {
     _throw_exc_format(env, error, "tcsetattr");
 
   // see: man ptmx
-  error = ptsname_r(master_fd.get(), slave_name, SLAVE_NAME_MAX_SIZE);
+  error = ttyname_r(master_fd.get(), slave_name, SLAVE_NAME_MAX_SIZE);
   if (error)
-    _throw_exc_format(env, error, "ptsname_r");
+    _throw_exc_format(env, error, "ttyname_r");
   error = grantpt(master_fd.get());
   if (error)
     _throw_exc_format(env, error, "grantpt");


### PR DESCRIPTION
This PR introduces an attach argument `remote` which allows the gdb client to attach to a remote gdb server.

e.g.:

```
attachArguments = {
    ...
    remote: localhost:3456,
    ...
}
```