### PR TITLE
Add support for attaching to a remote gdb server

### DIFF
--- a/src/GDBBackend.ts
+++ b/src/GDBBackend.ts
@@ -126,6 +126,10 @@ export class GDBBackend extends events.EventEmitter {
         return this.sendCommand('-gdb-exit');
     }
 
+    public sendTargetSelectRemote(remote: string) {
+        return this.sendCommand(`-target-select remote ${remote}`);
+    }
+
     private nextToken() {
         return this.token++;
     }


### PR DESCRIPTION
This PR introduces an attach argument `remote` which allows the gdb client to attach to a remote gdb server.

e.g.:

```
attachArguments = {
    ...
    remote: localhost:3456,
    ...
}
```