### PR TITLE
Only use PTYs when on Linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 compile_commands.json
 node_modules
+/.vscode/ipch/
 /build/
 /dist/
 /test-reports/

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,8 +5,9 @@
             'sources': ['src/native/pty.cc'],
             'conditions': [
                 ['OS=="win"', { 'defines': ['WINDOWS', 'NAPI_CPP_EXCEPTIONS'] }],
+                ['OS=="mac"', { 'defines': ['MAC'] }],
+                ['OS=="linux"', { 'defines': ['LINUX'] }],
             ],
-
             # https://github.com/nodejs/node/blob/master/doc/api/n-api.md#n-api-version-matrix
             'defines': ['NAPI_VERSION=2'],
         },

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -118,7 +118,7 @@ export class GDBDebugSession extends LoggingDebugSession {
     protected initializeRequest(response: DebugProtocol.InitializeResponse,
         args: DebugProtocol.InitializeRequestArguments): void {
         this.supportsRunInTerminalRequest = args.supportsRunInTerminalRequest === true;
-        this.supportsGdbConsole = os.platform() !== 'win32' && this.supportsRunInTerminalRequest;
+        this.supportsGdbConsole = os.platform() === 'linux' && this.supportsRunInTerminalRequest;
         response.body = response.body || {};
         response.body.supportsConfigurationDoneRequest = true;
         response.body.supportsSetVariable = true;

--- a/src/native/pty.cc
+++ b/src/native/pty.cc
@@ -21,7 +21,7 @@ static void _throw_exc(const Napi::Env env, const char *message) {
   throw Napi::Error::New(env, message);
 }
 
-#ifndef WINDOWS
+#ifdef LINUX
 /**
  * Takes an error code and throws a pretty JS error such as:
  * "function_name: errormsg".
@@ -49,9 +49,9 @@ static void _throw_exc_format(const Napi::Env env, int error,
 
 static Napi::Value create_pty(const Napi::CallbackInfo &info) {
   Napi::Env env = info.Env();
-#ifdef WINDOWS
+#ifndef LINUX
   // Windows does not supports TTYs.
-  _throw_exc(env, ".create_pty() is not supported on Windows");
+  _throw_exc(env, ".create_pty() is not supported on this platform");
 #else
   // master_fd will be closed on scope exit if an error is thrown.
   scoped_fd master_fd(open("/dev/ptmx", O_RDWR));


### PR DESCRIPTION
The API we are using to create pseudo-terminals has some quirks when on
Mac, and the terminal concept on Windows is quite different. This commit
makes it so we only ever use/compile the native module to handle PTYs
when on Linux.

Closes https://github.com/eclipse-cdt/cdt-gdb-adapter/pull/103

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>