### PR TITLE
Use protected fields for easy overriding

### DIFF
--- a/src/GDBBackend.ts
+++ b/src/GDBBackend.ts
@@ -35,10 +35,10 @@ export declare interface GDBBackend {
 }
 
 export class GDBBackend extends events.EventEmitter {
-    private parser = new MIParser(this);
-    private out?: Writable;
-    private token = 0;
-    private proc?: ChildProcess;
+    protected parser = new MIParser(this);
+    protected out?: Writable;
+    protected token = 0;
+    protected proc?: ChildProcess;
 
     public spawn(requestArgs: LaunchRequestArguments | AttachRequestArguments) {
         const gdb = requestArgs.gdb ? requestArgs.gdb : 'gdb';
@@ -136,7 +136,7 @@ export class GDBBackend extends events.EventEmitter {
         return this.sendCommand('-gdb-exit');
     }
 
-    private nextToken() {
+    protected nextToken() {
         return this.token++;
     }
 }

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -88,12 +88,12 @@ export class GDBDebugSession extends LoggingDebugSession {
     /* A reference to the logger to be used by subclasses */
     protected logger: Logger.Logger;
 
-    private frameHandles = new Handles<FrameReference>();
-    private variableHandles = new Handles<VariableReference>();
+    protected frameHandles = new Handles<FrameReference>();
+    protected variableHandles = new Handles<VariableReference>();
 
-    private threads: Thread[] = [];
+    protected threads: Thread[] = [];
 
-    private waitPaused?: (value?: void | PromiseLike<void>) => void;
+    protected waitPaused?: (value?: void | PromiseLike<void>) => void;
 
     constructor() {
         super();
@@ -708,7 +708,7 @@ export class GDBDebugSession extends LoggingDebugSession {
         }
     }
 
-    private async handleVariableRequestFrame(ref: FrameVariableReference): Promise<DebugProtocol.Variable[]> {
+    protected async handleVariableRequestFrame(ref: FrameVariableReference): Promise<DebugProtocol.Variable[]> {
         // initialize variables array and dereference the frame handle
         const variables: DebugProtocol.Variable[] = [];
         const frame = this.frameHandles.get(ref.frameHandle);
@@ -828,7 +828,7 @@ export class GDBDebugSession extends LoggingDebugSession {
         return Promise.resolve(variables);
     }
 
-    private async handleVariableRequestObject(ref: ObjectVariableReference): Promise<DebugProtocol.Variable[]> {
+    protected async handleVariableRequestObject(ref: ObjectVariableReference): Promise<DebugProtocol.Variable[]> {
         // initialize variables array and dereference the frame handle
         const variables: DebugProtocol.Variable[] = [];
         const frame = this.frameHandles.get(ref.frameHandle);
@@ -941,12 +941,12 @@ export class GDBDebugSession extends LoggingDebugSession {
         return Promise.resolve(variables);
     }
 
-    private async getAddr(varobj: varMgr.VarObjType) {
+    protected async getAddr(varobj: varMgr.VarObjType) {
         const addr = await mi.sendDataEvaluateExpression(this.gdb, `&(${varobj.expression})`);
         return addr.value ? addr.value : varobj.value;
     }
 
-    private isChildOfClass(child: mi.MIVarChild): boolean {
+    protected isChildOfClass(child: mi.MIVarChild): boolean {
         return child.type === undefined && child.value === '' &&
             (child.exp === 'public' || child.exp === 'protected' || child.exp === 'private');
     }

--- a/src/MIParser.ts
+++ b/src/MIParser.ts
@@ -12,12 +12,12 @@ import { logger } from 'vscode-debugadapter/lib/logger';
 import { GDBBackend } from './GDBBackend';
 
 export class MIParser {
-    private line = '';
-    private pos = 0;
-    private commandQueue: any = {};
-    private waitReady?: (value?: void | PromiseLike<void>) => void;
+    protected line = '';
+    protected pos = 0;
+    protected commandQueue: any = {};
+    protected waitReady?: (value?: void | PromiseLike<void>) => void;
 
-    constructor(private gdb: GDBBackend) {
+    constructor(protected gdb: GDBBackend) {
     }
 
     public parse(stream: Readable): Promise<void> {
@@ -43,7 +43,7 @@ export class MIParser {
         this.commandQueue[token] = command;
     }
 
-    private next() {
+    protected next() {
         if (this.pos < this.line.length) {
             return this.line[this.pos++];
         } else {
@@ -51,15 +51,15 @@ export class MIParser {
         }
     }
 
-    private back() {
+    protected back() {
         this.pos--;
     }
 
-    private restOfLine() {
+    protected restOfLine() {
         return this.line.substr(this.pos);
     }
 
-    private handleToken(firstChar: string) {
+    protected handleToken(firstChar: string) {
         let token = firstChar;
         let c = this.next();
         while (c && c >= '0' && c <= '9') {
@@ -70,7 +70,7 @@ export class MIParser {
         return token;
     }
 
-    private handleCString() {
+    protected handleCString() {
         let c = this.next();
         if (!c || c !== '"') {
             return null;
@@ -108,7 +108,7 @@ export class MIParser {
         return cstring;
     }
 
-    private handleString() {
+    protected handleString() {
         let str = '';
         for (let c = this.next(); c; c = this.next()) {
             if (c === '=' || c === ',') {
@@ -121,7 +121,7 @@ export class MIParser {
         return str;
     }
 
-    private handleObject() {
+    protected handleObject() {
         let c = this.next();
         const result: any = {};
         if (c === '{') {
@@ -145,7 +145,7 @@ export class MIParser {
         }
     }
 
-    private handleArray() {
+    protected handleArray() {
         let c = this.next();
         const result: any[] = [];
         if (c === '[') {
@@ -166,7 +166,7 @@ export class MIParser {
         }
     }
 
-    private handleValue(): any {
+    protected handleValue(): any {
         const c = this.next();
         this.back();
         switch (c) {
@@ -186,7 +186,7 @@ export class MIParser {
         return null;
     }
 
-    private handleAsyncData() {
+    protected handleAsyncData() {
         const result: any = { };
 
         let c = this.next();
@@ -201,21 +201,21 @@ export class MIParser {
         return result;
     }
 
-    private handleConsoleStream() {
+    protected handleConsoleStream() {
         const msg = this.handleCString();
         if (msg) {
             this.gdb.emit('consoleStreamOutput', msg, 'stdout');
         }
     }
 
-    private handleLogStream() {
+    protected handleLogStream() {
         const msg = this.handleCString();
         if (msg) {
             logger.log(msg);
         }
     }
 
-    private handleLine() {
+    protected handleLine() {
         let c = this.next();
         if (!c) {
             return;


### PR DESCRIPTION
Signed-off-by: thegecko <rob.moran@arm.com>

This PR modifies all `private` fields so they become `protected`.

As inheriting from this debug adapter is a recommended use case, this change makes overriding base fields a lot easier and avoids having to duplicate code in inherited classes.

Our specific use case was to override the variables functionality to introduce new scopes, but it seemed sensible (and trivial) to extend this to all private fields.
