### PR TITLE
Store each mocha run in its own junit file

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "test": "yarn test:integration && yarn test:pty && yarn test:integration --run-in-terminal",
-    "test:integration": "mocha --reporter mocha-jenkins-reporter dist/integration-tests/*.spec.js",
-    "test:pty": "mocha --reporter mocha-jenkins-reporter dist/native/*.spec.js"
+    "test": "yarn test:integration && yarn test:pty && yarn test:integration-run-in-terminal",
+    "test:integration": "JUNIT_REPORT_PATH=test-reports/integration.xml JUNIT_REPORT_STACK=1 JUNIT_REPORT_PACKAGES=1 mocha --reporter mocha-jenkins-reporter dist/integration-tests/*.spec.js",
+    "test:integration-run-in-terminal": "JUNIT_REPORT_PATH=test-reports/integration-run-in-terminal.xml JUNIT_REPORT_STACK=1 JUNIT_REPORT_PACKAGES=1 mocha --run-in-terminal --reporter mocha-jenkins-reporter dist/integration-tests/*.spec.js",
+    "test:pty": "JUNIT_REPORT_PATH=test-reports/native.xml JUNIT_REPORT_STACK=1 JUNIT_REPORT_PACKAGES=1 mocha --reporter mocha-jenkins-reporter dist/native/*.spec.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This needs to be in the package.json because mocha is
run repeatedly during one run of `yarn test` and therefore
the REPORT_PATH must be different for each invocation.