### PR TITLE
Add async status event for '+'

### DIFF
--- a/src/GDBBackend.ts
+++ b/src/GDBBackend.ts
@@ -28,10 +28,10 @@ export interface MIGDBShowResponse extends MIResponse {
 
 export declare interface GDBBackend {
     on(event: 'consoleStreamOutput', listener: (output: string, category: string) => void): this;
-    on(event: 'execAsync' | 'notifyAsync', listener: (asyncClass: string, data: any) => void): this;
+    on(event: 'execAsync' | 'notifyAsync' | 'statusAsync', listener: (asyncClass: string, data: any) => void): this;
 
     emit(event: 'consoleStreamOutput', output: string, category: string): boolean;
-    emit(event: 'execAsync' | 'notifyAsync', asyncClass: string, data: any): boolean;
+    emit(event: 'execAsync' | 'notifyAsync' | 'statusAsync', asyncClass: string, data: any): boolean;
 }
 
 export class GDBBackend extends events.EventEmitter {

--- a/src/MIParser.ts
+++ b/src/MIParser.ts
@@ -258,6 +258,11 @@ export class MIParser {
                 const execClass = this.handleString();
                 this.gdb.emit('execAsync', execClass, this.handleAsyncData());
                 break;
+            case '+':
+                logger.verbose('GDB status async: ' + this.restOfLine());
+                const statusClass = this.handleString();
+                this.gdb.emit('statusAsync', statusClass, this.handleAsyncData());
+                break;
             case '(':
                 if (this.waitReady) {
                     this.waitReady();


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

This PR adds support for the status event output from MI which uses the `+` character.
Tested for status output from image download progress on remote debugging.