### PR TITLE
Add known notify classes

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -693,10 +693,13 @@ export class GDBDebugSession extends LoggingDebugSession {
             case 'thread-created':
                 this.threads.push(this.convertThread(notifyData));
                 break;
+            case 'thread-selected':
+            case 'thread-exited':
             case 'thread-group-added':
             case 'thread-group-started':
             case 'library-loaded':
             case 'breakpoint-modified':
+            case 'breakpoint-deleted':
                 // Known unhandled notifies
                 break;
             default:


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

Add a few known gdb notify classes to suppress warnings.

Split from #130 