### PR TITLE
Support allThreadsStopped marker on StoppedEvent

### DIFF
--- a/src/stoppedEvent.ts
+++ b/src/stoppedEvent.ts
@@ -1,0 +1,32 @@
+/*********************************************************************
+ * Copyright (c) 2019 Arm Ltd. and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+import { Event } from 'vscode-debugadapter';
+import { DebugProtocol } from 'vscode-debugprotocol';
+
+export class StoppedEvent extends Event implements DebugProtocol.StoppedEvent {
+    public body: {
+        reason: string;
+        threadId?: number;
+        allThreadsStopped?: boolean;
+    };
+
+    constructor(reason: string, threadId: number, allThreadsStopped: boolean = false) {
+        super('stopped');
+
+        this.body = {
+            reason,
+            allThreadsStopped,
+        };
+
+        if (typeof threadId === 'number') {
+            this.body.threadId = threadId;
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: thegecko <rob.moran@arm.com>

The StoppedEvent raised from the adapter supports a boolean `allThreadsStopped` flag to indicate to the UI that all threads have stopped.
Gdb returns this in the stopped resultData as `stopped-threads`.

This PR marries the two up to fix scenarios such as the following:

Before:

<img width="639" alt="Screenshot 2019-09-19 at 14 43 58" src="https://user-images.githubusercontent.com/61341/65249465-f0955900-daeb-11e9-87e1-56aa7febcc8e.png">

After:

<img width="671" alt="Screenshot 2019-09-19 at 14 43 12" src="https://user-images.githubusercontent.com/61341/65249472-f55a0d00-daeb-11e9-850f-98b490567a67.png">
