### PR TITLE
Support hit conditional breakpoints

### DIFF
--- a/src/integration-tests/breakpoints.spec.ts
+++ b/src/integration-tests/breakpoints.spec.ts
@@ -78,4 +78,46 @@ describe('breakpoints', async () => {
         const vars = await dc.variablesRequest({ variablesReference: vr });
         verifyVariable(vars.body.variables[0], 'count', 'int', '5');
     });
+
+    it('hits a hit conditional breakpoint with >', async () => {
+        await dc.setBreakpointsRequest({
+            source: {
+                name: 'count.c',
+                path: path.join(testProgramsDir, 'count.c'),
+            },
+            breakpoints: [
+                {
+                    column: 1,
+                    line: 4,
+                    hitCondition: '> 5',
+                },
+            ],
+        });
+        await dc.configurationDoneRequest();
+        const scope = await getScopes(dc);
+        const vr = scope.scopes.body.scopes[0].variablesReference;
+        const vars = await dc.variablesRequest({ variablesReference: vr });
+        verifyVariable(vars.body.variables[0], 'count', 'int', '5');
+    });
+
+    it('hits a hit conditional breakpoint without >', async () => {
+        await dc.setBreakpointsRequest({
+            source: {
+                name: 'count.c',
+                path: path.join(testProgramsDir, 'count.c'),
+            },
+            breakpoints: [
+                {
+                    column: 1,
+                    line: 4,
+                    hitCondition: '5',
+                },
+            ],
+        });
+        await dc.configurationDoneRequest();
+        const scope = await getScopes(dc);
+        const vr = scope.scopes.body.scopes[0].variablesReference;
+        const vars = await dc.variablesRequest({ variablesReference: vr });
+        verifyVariable(vars.body.variables[0], 'count', 'int', '4');
+    });
 });

--- a/src/mi/breakpoint.ts
+++ b/src/mi/breakpoint.ts
@@ -47,8 +47,10 @@ export async function sendBreakInsert(gdb: GDBBackend, request: {
     location: string;
 }): Promise<MIBreakInsertResponse> {
     // Todo: lots of options
+    const temp = request.temporary ? '-t ' : '';
+    const ignore = request.ignoreCount ? `-i ${request.ignoreCount} ` : '';
     const escapedLocation = gdb.standardEscape(request.location);
-    const result = await gdb.sendCommand<MIBreakInsertResponse>(`-break-insert ${escapedLocation}`);
+    const result = await gdb.sendCommand<MIBreakInsertResponse>(`-break-insert ${temp}${ignore}${escapedLocation}`);
 
     if (request.condition) {
         await gdb.sendCommand(`-break-condition ${result.bkpt.number} ${request.condition}`);


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

Introduce support for ignore counts via the `supportsHitConditionalBreakpoints` configuration.
