### PR TITLE
Fix undefined and empty string comparison

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -260,7 +260,10 @@ export class GDBDebugSession extends LoggingDebugSession {
                         if (vsbp.line !== line) {
                             return true;
                         }
-                        if (vsbp.condition !== gdbbp.cond) {
+                        // Ensure we can compare undefined and empty strings
+                        const insertCond = vsbp.condition || undefined;
+                        const tableCond = gdbbp.cond || undefined;
+                        if (insertCond !== tableCond) {
                             return true;
                         }
                         actual.push({


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

I came across a problem where breakpoints being set weren't being compared with existing breakpoints properly.

It boiled down to the conditions comparison being an empty string on one side and undefined on the other. As they didn't match, a new breakpoint was being added.

This PR fixes the issue by ensuring any empty strings are set to undefined beforehand.
