### PR TITLE
Initial support for log points

### DIFF
--- a/src/integration-tests/logpoints.spec.ts
+++ b/src/integration-tests/logpoints.spec.ts
@@ -1,0 +1,60 @@
+/*********************************************************************
+ * Copyright (c) 2019 Arm and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+import { join } from 'path';
+import { expect } from 'chai';
+import { CdtDebugClient } from './debugClient';
+import { LaunchRequestArguments } from '../GDBDebugSession';
+import {
+    standardBeforeEach,
+    gdbPath,
+    testProgramsDir,
+    openGdbConsole
+} from './utils';
+
+describe('logpoints', async () => {
+    let dc: CdtDebugClient;
+
+    beforeEach(async () => {
+        dc = await standardBeforeEach();
+
+        await dc.launchRequest({
+            verbose: true,
+            gdb: gdbPath,
+            program: join(testProgramsDir, 'count'),
+            openGdbConsole,
+        } as LaunchRequestArguments);
+    });
+
+    afterEach(async () => {
+        await dc.stop();
+    });
+
+    it('hits a logpoint', async () => {
+        const logMessage = 'log message';
+
+        await dc.setBreakpointsRequest({
+            source: {
+                name: 'count.c',
+                path: join(testProgramsDir, 'count.c'),
+            },
+            breakpoints: [
+                {
+                    column: 1,
+                    line: 4,
+                    logMessage,
+                },
+            ],
+        });
+        await dc.configurationDoneRequest();
+        let logEvent = await dc.waitForOutputEvent('console');
+        expect(logEvent.body.output).to.eq(logMessage);
+    });
+});


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

This PR adds initial support for log points (breakpoints which log a message instead of stopping).

Currently, the new functionality simply logs the message provided when the logpoint is hit, but the [specification](https://microsoft.github.io/debug-adapter-protocol/specification) outlines that it should support `Expressions within {} are interpolated`.

This isn't yet added, I'll follow up with a separate PR to interpolate expressions within `{}`.
