### PR TITLE
Added clean and docker scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "prepublish": "tsc",
+    "prepublish": "yarn build",
     "build": "tsc",
     "watch": "tsc -w",
+    "clean": "git clean -dfx",
+    "docker:build": "docker run --rm -it -v $(git rev-parse --show-toplevel):/work -w /work/$(git rev-parse --show-prefix) --cap-add=SYS_PTRACE --security-opt seccomp=unconfined quay.io/eclipse-cdt/cdt-infra-eclipse-full:latest yarn",
+    "docker:test": "docker run --rm -it -v $(git rev-parse --show-toplevel):/work -w /work/$(git rev-parse --show-prefix) --cap-add=SYS_PTRACE --security-opt seccomp=unconfined quay.io/eclipse-cdt/cdt-infra-eclipse-full:latest yarn test",
     "test": "yarn test:integration && yarn test:pty && yarn test:integration-run-in-terminal && yarn test:integration-remote-target && yarn test:integration-remote-target-run-in-terminal",
     "test:integration": "cross-env JUNIT_REPORT_PATH=test-reports/integration.xml JUNIT_REPORT_STACK=1 JUNIT_REPORT_PACKAGES=1 mocha --reporter mocha-jenkins-reporter dist/integration-tests/*.spec.js",
     "test:integration-run-in-terminal": "cross-env JUNIT_REPORT_PATH=test-reports/integration-run-in-terminal.xml JUNIT_REPORT_STACK=1 JUNIT_REPORT_PACKAGES=1 mocha --run-in-terminal --reporter mocha-jenkins-reporter dist/integration-tests/*.spec.js",


### PR DESCRIPTION
Signed-off-by: thegecko <rob.moran@arm.com>

With reference to the discussion on #12 and the instructions in the [readme](https://github.com/eclipse-cdt/cdt-gdb-adapter/blob/master/src/integration-tests/README.md#running-the-tests-using-docker), the docker commands successfully build and run tests on MacOS hosts.

This PR adds some convenience scripts to run those commands.

e.g. a full build and test within docker:

```
> yarn clean && yarn docker:build && yarn docker:test
```
