### PR TITLE
Fixed stackFrameRequest with thread ID

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -543,7 +543,8 @@ export class GDBDebugSession extends LoggingDebugSession {
             const levels = args.levels ? (args.levels > depth ? depth : args.levels) : depth;
             const lowFrame = args.startFrame || 0;
             const highFrame = lowFrame + levels - 1;
-            const listResult = await mi.sendStackListFramesRequest(this.gdb, { lowFrame, highFrame });
+            const threadId = args.threadId;
+            const listResult = await mi.sendStackListFramesRequest(this.gdb, { lowFrame, highFrame, threadId });
 
             const stack = listResult.stack.map((frame) => {
                 let source;

--- a/src/mi/stack.ts
+++ b/src/mi/stack.ts
@@ -32,10 +32,14 @@ export function sendStackListFramesRequest(gdb: GDBBackend, params: {
     noFrameFilters?: boolean;
     lowFrame?: number;
     highFrame?: number;
+    threadId?: number;
 }): Promise<{
     stack: MIFrameInfo[];
 }> {
     let command = '-stack-list-frames';
+    if (params.threadId) {
+        command += ` --thread ${params.threadId}`;
+    }
     if (params.noFrameFilters) {
         command += ' -no-frame-filters';
     }


### PR DESCRIPTION
Signed-off-by: Rob Moran <rob.moran@arm.com>

This PR fixes the `stackFrameRequest()` so that it supports the `thread ID` being passed in.

Without this fix, all stack frames returned are for the main thread and not the one selected from the UI.

Not sure how I'd write any tests for this.