### PR TITLE
Stack frame depth fix and thread details

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
     "url": "git+https://github.com/eclipse-cdt/cdt-gdb-adapter.git"
   },
   "author": "Eclipse CDT",
+  "contributors": [
+    "Rob Moran <github@thegecko.org>"
+  ],
   "license": "EPL-2.0",
   "bugs": {
     "url": "https://github.com/eclipse-cdt/cdt-gdb-adapter/issues"

--- a/src/mi/stack.ts
+++ b/src/mi/stack.ts
@@ -20,8 +20,12 @@ export interface MIStackListVariablesResponse extends MIResponse {
 
 export function sendStackInfoDepth(gdb: GDBBackend, params: {
     maxDepth: number;
+    threadId?: number;
 }): Promise<MIStackInfoDepthResponse> {
     let command = '-stack-info-depth';
+    if (params.threadId) {
+        command += ` --thread ${params.threadId}`;
+    }
     if (params.maxDepth) {
         command += ` ${params.maxDepth}`;
     }


### PR DESCRIPTION
This PR introduces two changes. they are both small, but happy to split them into 2 PRs if either are controversial.

- After fixing the stack trace request in #162 , I've noticed the command to retrieve the stack depth also wasn't supporting threads. This is now fixed so that the depth is returned for the specified thread and not the main one every time.

- Threads return optional details, these are now returned in the name to give the user more info:

<img width="456" alt="Screenshot 2019-12-20 at 09 52 05" src="https://user-images.githubusercontent.com/61341/71249382-eb2af300-2314-11ea-950a-54d29fead71a.png">

I've also taken the liberty of adding myself as a contributor.