### PR TITLE
Added TypeScript sources to published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,9 @@
     "dist/**/*.d.ts",
     "src/**/*.cc",
     "src/**/*.h",
+    "src/*.ts",
+    "src/mi/*.ts",
+    "src/native/*.ts",
     "install.js",
     "binding.gyp"
   ]


### PR DESCRIPTION
Including the TypeScript sources in the published package is important to enable debugging when the package is used in another project.

I explicitly listed the source folders to include to avoid `integration-tests` to be included.