### PR TITLE
Bug #167: Fix usage of -var-update

### DIFF
--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -700,7 +700,7 @@ export class GDBDebugSession extends LoggingDebugSession {
                     }
                     const children = await mi.sendVarListChildren(this.gdb, {
                         name: parentVarname,
-                        printValues: 'all-values',
+                        printValues: mi.MIVarPrintValues.all,
                     });
                     for (const child of children.children) {
                         if (this.isChildOfClass(child)) {
@@ -769,7 +769,6 @@ export class GDBDebugSession extends LoggingDebugSession {
                     false, varCreateResponse);
             } else {
                 const vup = await mi.sendVarUpdate(this.gdb, {
-                    threadId: frame.threadId,
                     name: varobj.varname,
                 });
                 const update = vup.changelist[0];
@@ -1056,7 +1055,6 @@ export class GDBDebugSession extends LoggingDebugSession {
                 if (varobj.isVar && !varobj.isChild) {
                     // request update from GDB
                     const vup = await mi.sendVarUpdate(this.gdb, {
-                        threadId: frame.threadId,
                         name: varobj.varname,
                     });
                     // if changelist is length 0, update is undefined
@@ -1172,14 +1170,14 @@ export class GDBDebugSession extends LoggingDebugSession {
         if (varobj) {
             children = await mi.sendVarListChildren(this.gdb, {
                 name: varobj.varname,
-                printValues: 'all-values',
+                printValues: mi.MIVarPrintValues.all,
             });
             parentVarname = varobj.varname;
         } else {
             // otherwise use the parent name passed in the variable reference
             children = await mi.sendVarListChildren(this.gdb, {
                 name: ref.varobjName,
-                printValues: 'all-values',
+                printValues: mi.MIVarPrintValues.all,
             });
         }
 
@@ -1191,7 +1189,7 @@ export class GDBDebugSession extends LoggingDebugSession {
                 const name = `${parentVarname}.${child.exp}`;
                 const objChildren = await mi.sendVarListChildren(this.gdb, {
                     name,
-                    printValues: 'all-values',
+                    printValues: mi.MIVarPrintValues.all,
                 });
                 for (const objChild of objChildren.children) {
                     const childName = `${name}.${objChild.exp}`;

--- a/src/mi/var.ts
+++ b/src/mi/var.ts
@@ -10,6 +10,12 @@
 import { GDBBackend } from '../GDBBackend';
 import { MIResponse } from './base';
 
+export enum MIVarPrintValues {
+    no = "0",
+    all = "1",
+    simple = "2",
+}
+
 export interface MIVarCreateResponse extends MIResponse {
     name: string;
     numchild: string;
@@ -90,14 +96,14 @@ export function sendVarCreate(gdb: GDBBackend, params: {
 }
 
 export function sendVarListChildren(gdb: GDBBackend, params: {
-    printValues?: 'no-values' | 'all-values' | 'simple-values';
+    printValues?: MIVarPrintValues.no | MIVarPrintValues.all | MIVarPrintValues.simple;
     name: string;
     from?: number;
     to?: number;
 }): Promise<MIVarListChildrenResponse> {
     let command = '-var-list-children';
     if (params.printValues) {
-        command += ` --${params.printValues}`;
+        command += ` ${params.printValues}`;
     }
     command += ` ${params.name}`;
     if (params.from && params.to) {
@@ -108,12 +114,14 @@ export function sendVarListChildren(gdb: GDBBackend, params: {
 }
 
 export function sendVarUpdate(gdb: GDBBackend, params: {
-    threadId?: number;
     name?: string;
+    printValues?: MIVarPrintValues.no | MIVarPrintValues.all | MIVarPrintValues.simple;
 }): Promise<MIVarUpdateResponse> {
     let command = '-var-update';
-    if (params.threadId) {
-        command += ` ${params.threadId}`;
+    if (params.printValues) {
+        command += ` ${params.printValues}`;
+    } else {
+        command += ` ${MIVarPrintValues.all}`;
     }
     if (params.name) {
         command += ` ${params.name}`;

--- a/src/varManager.ts
+++ b/src/varManager.ts
@@ -92,7 +92,7 @@ export class VarManager {
     public async updateVar(frameId: number, threadId: number, depth: number, varobj: VarObjType)
         : Promise<VarObjType> {
         let returnVar = varobj;
-        const vup = await sendVarUpdate(this.gdb, { threadId, name: varobj.varname });
+        const vup = await sendVarUpdate(this.gdb, { name: varobj.varname });
         const update = vup.changelist[0];
         if (update) {
             if (update.in_scope === 'true') {


### PR DESCRIPTION
-var-update does not take a threadId as a parameter but it takes
a printValues parameter which can be:
0 or --no-values
1 or --all-values
2 or --simple-values

This patch also defines the PrintValues to be able to send number
to gdb instead of strings for easier/faster parsing.