### PR TITLE
pty: change the way we interact with ptys

### DIFF
--- a/src/GDBBackend.ts
+++ b/src/GDBBackend.ts
@@ -64,13 +64,13 @@ export class GDBBackend extends events.EventEmitter {
         // Useful when 'spawnInClientTerminal' isn't needed, but adapter is distributed on multiple OS's
         const { Pty } = await import('./native/pty');
         const pty = new Pty();
-        let args = [gdb, '-ex', `new-ui mi2 ${pty.name}`];
+        let args = [gdb, '-ex', `new-ui mi2 ${pty.slave_name}`];
         if (requestArgs.gdbArguments) {
             args = args.concat(requestArgs.gdbArguments);
         }
         await cb(args);
-        this.out = pty.master;
-        return this.parser.parse(pty.master);
+        this.out = pty.writer;
+        return this.parser.parse(pty.reader);
     }
 
     public pause() {

--- a/src/native/file.ts
+++ b/src/native/file.ts
@@ -1,0 +1,57 @@
+/*********************************************************************
+ * Copyright (c) 2020 Ericsson and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+import * as fs from 'fs';
+import { Duplex, Readable, Writable } from 'stream';
+
+export class File {
+
+    protected _duplex: Duplex;
+
+    get reader(): Readable {
+        return this._duplex;
+    }
+
+    get writer(): Writable {
+        return this._duplex;
+    }
+
+    constructor(
+        public fd: number,
+    ) {
+        const _this = this;
+        this._duplex = new Duplex({
+            read(size) {
+                fs.read(fd, Buffer.alloc(size), 0, size, null, (err, bytesRead, buffer) => {
+                    if (err) {
+                        console.error(fd, err.message);
+                        this.push(null);
+                    } else {
+                        this.push(buffer.slice(0, bytesRead));
+                    }
+                })
+            },
+            write(chunk, encoding, callback) {
+                const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding);
+                fs.write(fd, buffer, (err, written, _buffer) => {
+                    callback(err);
+                });
+            },
+            destroy(err, callback) {
+                fs.close(fd, callback);
+                _this.fd = -1;
+            }
+        })
+    }
+
+    destroy() {
+        this._duplex.destroy();
+    }
+}

--- a/src/native/forked-file.ts
+++ b/src/native/forked-file.ts
@@ -1,0 +1,63 @@
+/*********************************************************************
+ * Copyright (c) 2020 Ericsson and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *********************************************************************/
+
+import * as assert from 'assert';
+import { ChildProcess, spawn } from 'child_process';
+import { openSync } from 'fs';
+import { Readable, Writable } from 'stream';
+import { File } from './file';
+
+/**
+ * Open and read a file from a subprocess (mode `r+` only).
+ *
+ * This is useful when opening a ptmx/pts pair at the same time.
+ * When both files are opened by the same process, closing does not correctly release
+ * the read callbacks, leaving node hanging at exit.
+ *
+ * Instead, we open one of the two files in a subprocess in order to kill it once done,
+ * which will properly release read callbacks for some reason.
+ */
+export class ForkedFile {
+
+    protected _fork: ChildProcess;
+
+    get reader(): Readable {
+        return this._fork.stdout;
+    }
+
+    get writer(): Writable {
+        return this._fork.stdin;
+    }
+
+    constructor(
+        readonly path: string,
+    ) {
+        // To write to the file, we'll write to stdin.
+        // To read from the file, we'll read from stdout.
+        this._fork = spawn(process.execPath, [...process.execArgv, __filename, path], {
+            stdio: ['pipe', 'pipe', 'inherit'],
+        });
+    }
+
+    destroy(): void {
+        if (this._fork.exitCode === null && this._fork.signalCode === null) {
+            this._fork.kill();
+        }
+    }
+}
+
+const [, script, path] = process.argv;
+// Check if we are forked:
+if (script === __filename) {
+    assert(typeof path === 'string', 'argv[2] must be a string');
+    const file = new File(openSync(path, 'r+'));
+    process.stdin.pipe(file.writer);
+    file.reader.pipe(process.stdout);
+}

--- a/src/native/pty.ts
+++ b/src/native/pty.ts
@@ -7,28 +7,28 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  *********************************************************************/
-import { Socket } from 'net';
 
-// tslint:disable-next-line:variable-name
-const tty_wrap = (process as any).binding('tty_wrap');
+import { File } from './file';
+export { File };
+
 // tslint:disable-next-line:no-var-requires
 const pty = require('../../build/Release/pty.node');
+
 interface PtyHandles {
     master_fd: number;
     slave_name: string;
 }
 
-export class Pty {
+/**
+ * Represents the master-side of a pseudo-terminal master/slave pair.
+ */
+export class Pty extends File {
 
-    public master: Socket;
-    public readonly name: string;
+    public readonly slave_name: string;
 
     constructor() {
-        const handles: PtyHandles = pty.create_pty();
-        const backup = tty_wrap.guessHandleType;
-        tty_wrap.guessHandleType = () => 'PIPE';
-        this.master = new Socket({ fd: handles.master_fd });
-        tty_wrap.guessHandleType = backup;
-        this.name = handles.slave_name;
+        const handles = pty.create_pty() as PtyHandles;
+        super(handles.master_fd);
+        this.slave_name = handles.slave_name;
     }
 }


### PR DESCRIPTION
The hack using sockets was causing troubles where some lines were not
correctly sent. This commit tries to simplify the pty fd handling.

There is an issue when opening both the master and slave ends from the
same process on Node though. When doing so Node will hang at exit
because of stuck read calls in the eventloop. I wasn't able to figure
out the cause, so a hack I used was to open the slave end into a
subprocess that we kill once done with it. This only impacts our test
suite.

Signed-off-by: Paul Maréchal <paul.marechal@ericsson.com>